### PR TITLE
feat: typed command errors + structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "adhd-ranch-domain",
  "adhd-ranch-http-api",
  "adhd-ranch-storage",
+ "log",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -17,6 +18,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-log",
  "tauri-plugin-notification",
  "time",
  "tokio",
@@ -80,6 +82,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +117,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +147,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -382,6 +418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +470,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +519,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -578,6 +684,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1009,6 +1121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1180,6 +1311,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1563,6 +1700,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2150,6 +2290,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mac-notification-sys"
@@ -2364,6 +2507,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3017,6 +3169,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,11 +3228,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3070,8 +3250,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3089,6 +3279,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3184,6 +3377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +3417,52 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3322,6 +3570,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
@@ -3566,6 +3820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,6 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3792,6 +4053,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3926,6 +4193,28 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -4130,7 +4419,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4162,6 +4453,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4542,6 +4848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4558,6 +4870,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version-compare"
@@ -5431,6 +5749,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/crates/commands/src/error.rs
+++ b/crates/commands/src/error.rs
@@ -1,7 +1,8 @@
 use adhd_ranch_domain::ProposalValidationError;
 use adhd_ranch_storage::{FocusStoreError, JsonlError};
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "type", content = "message", rename_all = "snake_case")]
 pub enum CommandError {
     BadRequest(String),
     NotFound(String),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,8 +25,10 @@ adhd-ranch-http-api = { path = "../crates/http-api" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1", features = ["v7"] }
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-notification = "2"
+tauri-plugin-log = "2"
+log = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,9 +1,8 @@
 pub mod cap_notifier;
 pub mod menu;
 pub mod paths;
-pub mod pig_hittest;
-pub mod tray;
 pub mod window_always_on_top;
+pub mod window_autosave;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,7 +44,6 @@ pub fn run() {
             ui_bridge::append_task,
             ui_bridge::delete_task,
             ui_bridge::get_caps,
-            ui_bridge::update_pig_rects,
         ])
         .menu(move |handle| menu::build(handle, settings.widget.always_on_top));
 
@@ -88,23 +86,13 @@ pub fn run() {
 
         app.manage(ui_bridge::CommandsState(commands));
 
-        let tray_icon = tray::setup(app.handle(), store.clone(), settings)?;
-
         let focuses_watcher = install_change_handlers(
             &focuses_root,
             vec![
                 emit_event_handler(app.handle().clone(), FOCUSES_CHANGED_EVENT),
                 evaluate_caps_handler(evaluator.clone()),
-                tray::rebuild_handler(
-                    tray_icon.clone(),
-                    app.handle().clone(),
-                    store.clone(),
-                    settings,
-                ),
             ],
         )?;
-
-        app.manage(TrayHandle(tray_icon));
         let proposals_watcher = install_change_handlers(
             proposals_path.parent().expect("proposals path has parent"),
             vec![emit_event_handler(
@@ -120,37 +108,10 @@ pub fn run() {
         let server = install_http_server(store, queue, decision_log)?;
         app.manage(server);
 
-        let hittester = pig_hittest::PigHitTester::new();
-        app.manage(ui_bridge::PigHitState(hittester.clone()));
-
         if let Some(window) = app.get_webview_window("main") {
-            // Size the overlay to cover the primary monitor.
-            if let Ok(Some(monitor)) = window.current_monitor() {
-                let size = monitor.size();
-                let pos = monitor.position();
-                let _ = window.set_size(tauri::PhysicalSize::new(size.width, size.height));
-                let _ = window.set_position(tauri::PhysicalPosition::new(pos.x, pos.y));
-            }
-
-            window_always_on_top::apply(&window, true);
+            window_always_on_top::apply(&window, settings.widget.always_on_top);
+            window_autosave::apply(&window, "adhd-ranch-main");
             let _ = window.show();
-
-            // Polling thread: toggle click-through based on pig hit-test.
-            let app_handle = app.handle().clone();
-            let window_clone = window.clone();
-            std::thread::spawn(move || {
-                let mut last_over = false;
-                loop {
-                    if let Ok(cursor) = app_handle.cursor_position() {
-                        let over = hittester.is_hit(cursor.x, cursor.y);
-                        if over != last_over {
-                            let _ = window_clone.set_ignore_cursor_events(!over);
-                            last_over = over;
-                        }
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(16));
-                }
-            });
         }
 
         Ok(())
@@ -189,9 +150,6 @@ struct WatcherHandles {
     _focuses: FocusWatcher,
     _proposals: FocusWatcher,
 }
-
-#[allow(dead_code)]
-struct TrayHandle<R: tauri::Runtime>(tauri::tray::TrayIcon<R>);
 
 type ChangeHandler = Box<dyn Fn() + Send + 'static>;
 

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,8 +1,9 @@
 pub mod cap_notifier;
 pub mod menu;
 pub mod paths;
+pub mod pig_hittest;
+pub mod tray;
 pub mod window_always_on_top;
-pub mod window_autosave;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,6 +31,7 @@ pub fn run() {
     let event_settings_path = settings_path.clone();
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![
             ui_bridge::health,
@@ -43,6 +45,7 @@ pub fn run() {
             ui_bridge::append_task,
             ui_bridge::delete_task,
             ui_bridge::get_caps,
+            ui_bridge::update_pig_rects,
         ])
         .menu(move |handle| menu::build(handle, settings.widget.always_on_top));
 
@@ -85,13 +88,23 @@ pub fn run() {
 
         app.manage(ui_bridge::CommandsState(commands));
 
+        let tray_icon = tray::setup(app.handle(), store.clone(), settings)?;
+
         let focuses_watcher = install_change_handlers(
             &focuses_root,
             vec![
                 emit_event_handler(app.handle().clone(), FOCUSES_CHANGED_EVENT),
                 evaluate_caps_handler(evaluator.clone()),
+                tray::rebuild_handler(
+                    tray_icon.clone(),
+                    app.handle().clone(),
+                    store.clone(),
+                    settings,
+                ),
             ],
         )?;
+
+        app.manage(TrayHandle(tray_icon));
         let proposals_watcher = install_change_handlers(
             proposals_path.parent().expect("proposals path has parent"),
             vec![emit_event_handler(
@@ -107,10 +120,37 @@ pub fn run() {
         let server = install_http_server(store, queue, decision_log)?;
         app.manage(server);
 
+        let hittester = pig_hittest::PigHitTester::new();
+        app.manage(ui_bridge::PigHitState(hittester.clone()));
+
         if let Some(window) = app.get_webview_window("main") {
-            window_always_on_top::apply(&window, settings.widget.always_on_top);
-            window_autosave::apply(&window, "adhd-ranch-main");
+            // Size the overlay to cover the primary monitor.
+            if let Ok(Some(monitor)) = window.current_monitor() {
+                let size = monitor.size();
+                let pos = monitor.position();
+                let _ = window.set_size(tauri::PhysicalSize::new(size.width, size.height));
+                let _ = window.set_position(tauri::PhysicalPosition::new(pos.x, pos.y));
+            }
+
+            window_always_on_top::apply(&window, true);
             let _ = window.show();
+
+            // Polling thread: toggle click-through based on pig hit-test.
+            let app_handle = app.handle().clone();
+            let window_clone = window.clone();
+            std::thread::spawn(move || {
+                let mut last_over = false;
+                loop {
+                    if let Ok(cursor) = app_handle.cursor_position() {
+                        let over = hittester.is_hit(cursor.x, cursor.y);
+                        if over != last_over {
+                            let _ = window_clone.set_ignore_cursor_events(!over);
+                            last_over = over;
+                        }
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(16));
+                }
+            });
         }
 
         Ok(())
@@ -149,6 +189,9 @@ struct WatcherHandles {
     _focuses: FocusWatcher,
     _proposals: FocusWatcher,
 }
+
+#[allow(dead_code)]
+struct TrayHandle<R: tauri::Runtime>(tauri::tray::TrayIcon<R>);
 
 type ChangeHandler = Box<dyn Fn() + Send + 'static>;
 

--- a/src-tauri/src/ui_bridge/mod.rs
+++ b/src-tauri/src/ui_bridge/mod.rs
@@ -9,11 +9,8 @@ use adhd_ranch_domain::{Caps, Focus, Proposal};
 use tauri::State;
 
 use crate::api::Health;
-use crate::app::pig_hittest::{PigHitTester, PigRect};
 
 pub struct CommandsState(pub Arc<Commands>);
-
-pub struct PigHitState(pub PigHitTester);
 
 #[tauri::command]
 pub fn health() -> Health {
@@ -115,11 +112,6 @@ pub fn reject_proposal(
         .reject_proposal(&id)
         .inspect(|_| log::info!("proposal {id} rejected"))
         .inspect_err(|e| log::error!("reject_proposal({id:?}): {e}"))
-}
-
-#[tauri::command]
-pub fn update_pig_rects(rects: Vec<PigRect>, state: State<'_, PigHitState>) {
-    state.0.update(rects);
 }
 
 #[tauri::command]

--- a/src-tauri/src/ui_bridge/mod.rs
+++ b/src-tauri/src/ui_bridge/mod.rs
@@ -1,15 +1,19 @@
 use std::sync::Arc;
 
 use adhd_ranch_commands::{
-    Commands, CreateFocusInput, CreatedFocus, CreatedProposal, DecisionOutcome, ProposalEdit,
+    CommandError, Commands, CreateFocusInput, CreatedFocus, CreatedProposal, DecisionOutcome,
+    ProposalEdit,
 };
 use adhd_ranch_domain::{Caps, Focus, Proposal};
 
 use tauri::State;
 
 use crate::api::Health;
+use crate::app::pig_hittest::{PigHitTester, PigRect};
 
 pub struct CommandsState(pub Arc<Commands>);
+
+pub struct PigHitState(pub PigHitTester);
 
 #[tauri::command]
 pub fn health() -> Health {
@@ -17,13 +21,19 @@ pub fn health() -> Health {
 }
 
 #[tauri::command]
-pub fn list_focuses(state: State<'_, CommandsState>) -> Result<Vec<Focus>, String> {
-    state.0.list_focuses().map_err(|e| e.to_string())
+pub fn list_focuses(state: State<'_, CommandsState>) -> Result<Vec<Focus>, CommandError> {
+    state
+        .0
+        .list_focuses()
+        .inspect_err(|e| log::error!("list_focuses: {e}"))
 }
 
 #[tauri::command]
-pub fn list_proposals(state: State<'_, CommandsState>) -> Result<Vec<Proposal>, String> {
-    state.0.list_proposals().map_err(|e| e.to_string())
+pub fn list_proposals(state: State<'_, CommandsState>) -> Result<Vec<Proposal>, CommandError> {
+    state
+        .0
+        .list_proposals()
+        .inspect_err(|e| log::error!("list_proposals: {e}"))
 }
 
 #[tauri::command]
@@ -31,19 +41,24 @@ pub fn create_focus(
     title: String,
     description: Option<String>,
     state: State<'_, CommandsState>,
-) -> Result<CreatedFocus, String> {
+) -> Result<CreatedFocus, CommandError> {
     state
         .0
         .create_focus(CreateFocusInput {
-            title,
+            title: title.clone(),
             description: description.unwrap_or_default(),
         })
-        .map_err(|e| e.to_string())
+        .inspect(|f| log::info!("focus created: {}", f.id))
+        .inspect_err(|e| log::error!("create_focus({title:?}): {e}"))
 }
 
 #[tauri::command]
-pub fn delete_focus(focus_id: String, state: State<'_, CommandsState>) -> Result<(), String> {
-    state.0.delete_focus(&focus_id).map_err(|e| e.to_string())
+pub fn delete_focus(focus_id: String, state: State<'_, CommandsState>) -> Result<(), CommandError> {
+    state
+        .0
+        .delete_focus(&focus_id)
+        .inspect(|_| log::info!("focus deleted: {focus_id}"))
+        .inspect_err(|e| log::error!("delete_focus({focus_id:?}): {e}"))
 }
 
 #[tauri::command]
@@ -51,11 +66,12 @@ pub fn append_task(
     focus_id: String,
     text: String,
     state: State<'_, CommandsState>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     state
         .0
         .append_task(&focus_id, &text)
-        .map_err(|e| e.to_string())
+        .inspect(|_| log::info!("task appended to {focus_id}"))
+        .inspect_err(|e| log::error!("append_task({focus_id:?}): {e}"))
 }
 
 #[tauri::command]
@@ -63,11 +79,12 @@ pub fn delete_task(
     focus_id: String,
     index: usize,
     state: State<'_, CommandsState>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     state
         .0
         .delete_task(&focus_id, index)
-        .map_err(|e| e.to_string())
+        .inspect(|_| log::info!("task {index} deleted from {focus_id}"))
+        .inspect_err(|e| log::error!("delete_task({focus_id:?}, {index}): {e}"))
 }
 
 #[tauri::command]
@@ -80,25 +97,39 @@ pub fn accept_proposal(
     id: String,
     edit: Option<ProposalEdit>,
     state: State<'_, CommandsState>,
-) -> Result<DecisionOutcome, String> {
+) -> Result<DecisionOutcome, CommandError> {
     state
         .0
         .accept_proposal(&id, edit.unwrap_or_default())
-        .map_err(|e| e.to_string())
+        .inspect(|o| log::info!("proposal {id} accepted → {:?}", o.target))
+        .inspect_err(|e| log::error!("accept_proposal({id:?}): {e}"))
 }
 
 #[tauri::command]
 pub fn reject_proposal(
     id: String,
     state: State<'_, CommandsState>,
-) -> Result<DecisionOutcome, String> {
-    state.0.reject_proposal(&id).map_err(|e| e.to_string())
+) -> Result<DecisionOutcome, CommandError> {
+    state
+        .0
+        .reject_proposal(&id)
+        .inspect(|_| log::info!("proposal {id} rejected"))
+        .inspect_err(|e| log::error!("reject_proposal({id:?}): {e}"))
+}
+
+#[tauri::command]
+pub fn update_pig_rects(rects: Vec<PigRect>, state: State<'_, PigHitState>) {
+    state.0.update(rects);
 }
 
 #[tauri::command]
 pub fn create_proposal(
     input: adhd_ranch_commands::CreateProposalInput,
     state: State<'_, CommandsState>,
-) -> Result<CreatedProposal, String> {
-    state.0.create_proposal(input).map_err(|e| e.to_string())
+) -> Result<CreatedProposal, CommandError> {
+    state
+        .0
+        .create_proposal(input)
+        .inspect(|p| log::info!("proposal created: {}", p.id))
+        .inspect_err(|e| log::error!("create_proposal: {e}"))
 }

--- a/src/api/focusWriter.ts
+++ b/src/api/focusWriter.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { CommandError } from "../types/error";
 
 export interface FocusWriter {
   createFocus(input: { title: string; description?: string }): Promise<{ id: string }>;
@@ -7,19 +8,28 @@ export interface FocusWriter {
   deleteTask(focusId: string, index: number): Promise<void>;
 }
 
+function logErr(op: string) {
+  return (e: unknown): never => {
+    console.error(`[adhd-ranch] ${op}`, e as CommandError);
+    throw e;
+  };
+}
+
 export function createTauriFocusWriter(): FocusWriter {
   return {
     createFocus({ title, description }) {
-      return invoke<{ id: string }>("create_focus", { title, description });
+      return invoke<{ id: string }>("create_focus", { title, description }).catch(
+        logErr("create_focus"),
+      );
     },
     deleteFocus(focusId: string) {
-      return invoke<void>("delete_focus", { focusId });
+      return invoke<void>("delete_focus", { focusId }).catch(logErr("delete_focus"));
     },
     appendTask(focusId: string, text: string) {
-      return invoke<void>("append_task", { focusId, text });
+      return invoke<void>("append_task", { focusId, text }).catch(logErr("append_task"));
     },
     deleteTask(focusId: string, index: number) {
-      return invoke<void>("delete_task", { focusId, index });
+      return invoke<void>("delete_task", { focusId, index }).catch(logErr("delete_task"));
     },
   };
 }

--- a/src/api/tauriProposalReader.ts
+++ b/src/api/tauriProposalReader.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { Proposal } from "../types/proposal";
+import type { CommandError } from "../types/error";
 import type { Unsubscribe } from "./focuses";
 import type {
   ProposalDecisionResult,
@@ -33,11 +34,21 @@ export function createTauriProposalReader(): ProposalReader {
 export function createTauriProposalWriter(): ProposalWriter {
   return {
     async accept(id: string, edit?: ProposalEdit): Promise<ProposalDecisionResult> {
-      const result = await invoke<RustDecisionResponse>("accept_proposal", { id, edit });
+      const result = await invoke<RustDecisionResponse>("accept_proposal", { id, edit }).catch(
+        (e: unknown): never => {
+          console.error("[adhd-ranch] accept_proposal", e as CommandError);
+          throw e;
+        },
+      );
       return { id: result.id, target: result.target };
     },
     async reject(id: string): Promise<ProposalDecisionResult> {
-      const result = await invoke<RustDecisionResponse>("reject_proposal", { id });
+      const result = await invoke<RustDecisionResponse>("reject_proposal", { id }).catch(
+        (e: unknown): never => {
+          console.error("[adhd-ranch] reject_proposal", e as CommandError);
+          throw e;
+        },
+      );
       return { id: result.id, target: result.target };
     },
   };

--- a/src/api/tauriProposalReader.ts
+++ b/src/api/tauriProposalReader.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { Proposal } from "../types/proposal";
 import type { CommandError } from "../types/error";
+import type { Proposal } from "../types/proposal";
 import type { Unsubscribe } from "./focuses";
 import type {
   ProposalDecisionResult,

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,6 @@
+export type CommandError =
+  | { type: "bad_request"; message: string }
+  | { type: "not_found"; message: string }
+  | { type: "already_exists"; message: string }
+  | { type: "validation"; message: string }
+  | { type: "internal"; message: string };


### PR DESCRIPTION
## Summary

- `CommandError` now derives `serde::Serialize` with `#[serde(tag = "type", content = "message")]` — errors cross the Tauri bridge as `{type: "not_found", message: "..."}` instead of opaque strings
- `tauri-plugin-log` wired in — Rust `log::` calls land in `~/Library/Logs/adhd-ranch/` (readable in Console.app or via `log stream --predicate 'process == "adhd-ranch"'`)
- `ui_bridge` returns `Result<T, CommandError>` on all commands; mutating ops logged at `info`, errors at `error`
- Frontend: `CommandError` discriminated union type in `src/types/error.ts`; mutation APIs log failures via `console.error` with structured error object

## Test plan

- [ ] `cargo test --workspace` passes (111 tests)
- [ ] `tsc --noEmit` clean
- [ ] Launch app, create a focus → `~/Library/Logs/adhd-ranch/` has log file with `focus created:` entry
- [ ] Attempt duplicate focus creation → log shows `already_exists` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured error handling with categorized command errors for clearer UI messages and propagation.
  * App-level logging added to capture runtime events and command results.

* **User-facing Improvements**
  * Commands now surface typed errors to the UI and client-side calls log failures for easier troubleshooting.

* **Chores**
  * Updated native deps/configuration to enable logging and tray-related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->