### PR TITLE
feat: pig overlay window + tray icon [012+013]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,15 +7,19 @@
 ## Ubiquitous Language
 
 ### Focus
+
 A top-level item the user is paying attention to. Represents a real-world goal (e.g. "Customer X bug"). Created manually by the user (via menu bar or hand-edit), or in v1.3+ via an accepted `new_focus` proposal. Owns a flat list of Tasks. Rendered in the UI as a Pig.
 
 ### Pig
+
 The visual representation of a Focus. A pixel-art sprite that wanders the screen. One pig = one Focus. Clicking a pig opens its detail card. Pigs are not stored — they are ephemeral projections of Focus state.
 
 ### Task
+
 A child item under a Focus. Single sentence. Created by user action or (v1.3+) by an accepted `add_task` proposal. Tree is capped at two levels — Focus → Task. No sub-tasks. Removed only by user action.
 
 ### Proposal
+
 A pending suggestion from the in-session agent at `/checkpoint` time. Three kinds: `add_task`, `new_focus`, `discard`. Held in a queue until the user accepts or rejects. **Deferred to v1.3** — not part of the current UI.
 
 ## Persistence
@@ -142,14 +146,8 @@ caps:
 alerts:
   system_notifications: true
 widget:
-  window_level: status   # floating | status | screensaver
+  always_on_top: true
 ```
-
-`widget.window_level` controls the macOS NSWindow level the popover sits at:
-
-- `floating` (3) — above normal windows, below the status bar.
-- `status` (25, default) — above status bar items; sane default for a tray widget.
-- `screensaver` (1000) — above absolutely everything, including fullscreen apps.
 
 Changes apply at app startup; restart the app to pick up edits.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,18 +2,21 @@
 
 ## Guiding metaphor
 
-**Issue tracking for a 5 year old.** A small number of buckets the user cares about right now. When something new happens, an adult (the in-session agent) decides which bucket it goes in. The user clears bullets when they're done. No tickets, no hierarchies, no fields beyond what a five-year-old could parse.
+**A ranch you can see from the corner of your eye.** Pixel pig sprites roam the screen — one per Focus. They walk slowly in the background. No interruption; no modal. You glance, you know what's on your plate. Click a pig to see its tasks. Clear a task from that card. The pigs don't demand attention; they just exist.
 
 ## Ubiquitous Language
 
 ### Focus
-A top-level item the user is paying attention to. Represents a real-world goal (e.g. "Customer X bug"). Created manually by the user, or via an accepted `new_focus` proposal. Owns a flat list of Tasks.
+A top-level item the user is paying attention to. Represents a real-world goal (e.g. "Customer X bug"). Created manually by the user (via menu bar or hand-edit), or in v1.3+ via an accepted `new_focus` proposal. Owns a flat list of Tasks. Rendered in the UI as a Pig.
+
+### Pig
+The visual representation of a Focus. A pixel-art sprite that wanders the screen. One pig = one Focus. Clicking a pig opens its detail card. Pigs are not stored — they are ephemeral projections of Focus state.
 
 ### Task
-A child item under a Focus. Single sentence. Created either by user action or by an accepted `add_task` proposal. Tree is capped at two levels — Focus → Task. No sub-tasks. Removed only by user action.
+A child item under a Focus. Single sentence. Created by user action or (v1.3+) by an accepted `add_task` proposal. Tree is capped at two levels — Focus → Task. No sub-tasks. Removed only by user action.
 
 ### Proposal
-A pending suggestion from the in-session agent at `/checkpoint` time. Three kinds: `add_task`, `new_focus`, `discard`. Held in a queue until the user accepts or rejects in the widget.
+A pending suggestion from the in-session agent at `/checkpoint` time. Three kinds: `add_task`, `new_focus`, `discard`. Held in a queue until the user accepts or rejects. **Deferred to v1.3** — not part of the current UI.
 
 ## Persistence
 
@@ -60,31 +63,21 @@ created_at: 2026-04-30T12:00:00Z
 - **No static binding from agent context to Focus.** Focus is a mental anchor identified by `title` + `description`. The in-session agent decides routing at `/checkpoint` time using the catalog returned by the app.
 - **App holds zero LLM logic.** All reasoning happens in the agent already running in the user's session.
 
-## Single-stage flow (v1)
+## Core interaction loop (v1.2)
 
-1. **Capture + route (in-session, one shot at `/checkpoint`):**
-   - User runs `/checkpoint` in their Claude Code session.
-   - Slash command instructs the agent to:
-     1. `GET http://127.0.0.1:<port>/focuses` → receive catalog `[{id, title, description}]`.
-     2. Compose ONE short sentence (≤12 words) summarizing what was just done.
-     3. Decide kind: `add_task` (fits an existing Focus) | `new_focus` (doesn't fit any) | `discard` (not worth tracking).
-     4. `POST http://127.0.0.1:<port>/proposals` with `{ kind, target_focus_id?, task_text?, new_focus?, summary, reasoning }`.
-   - App appends to `proposals.jsonl`. No app-side LLM call.
-   - One proposal per `/checkpoint`. User runs it again if multiple buckets affected.
+1. **Pigs roam the screen.** One pig per Focus, wandering at ~35px/s with slow random direction changes.
+2. **Click a pig.** `PigDetail` card opens near the pig: Focus title + Task list with `✗` per Task. Click-outside closes.
+3. **Clear a task.** Tap `✗` → `DELETE /focuses/{id}/tasks/{idx}` → markdown updated → pig's task list reflects change.
+4. **Create a Focus.** Menu bar item → "+ New Focus" → title + description → `POST /focuses` → new pig spawns.
+5. **Delete a Focus.** Menu bar item → Focus list → delete → pig disappears.
 
-2. **User confirmation (widget):**
-   - Popover layout (top → bottom):
-     1. List of Focuses with their Tasks. Each Task has an inline `✗` to clear it.
-     2. Collapsed-by-default tray: `📥 N pending` badge. Tap to expand.
-     3. Expanded tray: one inline card per proposal showing summary + suggested target Focus + `✓ / ✗ / edit`. Reasoning hidden behind `?`.
-   - Accept → mutation applied to Focus dir; row appended to `decisions.jsonl`.
-   - Reject → proposal dropped; row appended to `decisions.jsonl`.
-   - Edit → small modal lets user override target Focus or text before accepting.
-   - No auto-accept. No per-proposal system notifications. System notifications reserved for overload alerts.
-   - All Focuses are equal — no "current" highlight. No primary bucket.
-   - Empty/first-run: hero card "+ New Focus" + one-line tip ("create a bucket; run /checkpoint in any session").
+## Agent proposal flow (v1.3 — deferred)
 
-The bet: a naive "which of these focus titles+descriptions does this summary belong to?" prompt is enough. If it works, this becomes the foundation for v2 (ticket linking, cross-source bridging).
+1. User runs `/checkpoint` in a Claude Code session.
+2. Agent reads focus catalog, composes summary, POSTs proposal.
+3. App enqueues in `proposals.jsonl`.
+4. User reviews proposals via tray menu submenu or modal; accepts/rejects.
+5. Decisions appended to `decisions.jsonl`.
 
 ## LLM
 
@@ -103,14 +96,18 @@ App and skill are independent: app works UI-only without the skill; skill is use
 
 ## Application
 
-Single Tauri v2 desktop app written in Rust (core + frontend webview). Menubar/tray app via `TrayIconBuilder`; popover window is borderless, always-on-top, positioned near the tray icon by `tauri-plugin-positioner`.
+Single Tauri v2 desktop app written in Rust (core + frontend webview). Two surfaces:
+
+1. **Transparent overlay window** — fullscreen, always-on-top, no decorations. Renders pixel pig sprites via React. Click-through for non-pig areas via a Rust polling thread (`NSEvent.mouseLocation` at 16ms) that toggles `window.set_ignore_cursor_events`.
+2. **Menu bar item (tray)** — native NSMenu with Focus list, new-focus creation, quit. Red badge when over-cap.
 
 Responsibilities owned by the app:
 
 - Read/write per-Focus markdown files (frontmatter + body).
-- Watch `~/.adhd-ranch/focuses/` via `notify` crate; reflect external edits live.
-- Serve the localhost HTTP API.
+- Watch `~/.adhd-ranch/focuses/` via `notify` crate; reflect external edits live (pig count updates within 1s).
+- Serve the localhost HTTP API (for v1.3 `/checkpoint` flow).
 - Enforce caps + emit overload alerts (`tauri-plugin-notification`).
+- Poll mouse position in a background thread; maintain shared pig bounding boxes; toggle click-through.
 
 No separate CLI, no shell scripts. Rust core is the single implementation of read/write/cap logic.
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,8 +1,8 @@
 # PRD — adhd-ranch
 
-**Status:** Draft v1
+**Status:** Draft v1.2
 **Owner:** ryan
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-01
 
 ---
 
@@ -14,7 +14,7 @@ The problem isn't capacity. It's *signal compression*. The user needs a few buck
 
 ## Why now
 
-Agentic coding is the multiplier. A user with 3+ Claude Code sessions running at once has exactly the context-fragmentation this addresses. The skill/slash-command/hook surfaces of Claude Code make it feasible to get free, in-context summaries without separate LLM cost.
+Agentic coding is the multiplier. A user with 3+ Claude Code sessions running at once has exactly the context-fragmentation this addresses. The ambient pig overlay makes Focuses physically visible without demanding attention — the reminder is peripheral, not modal.
 
 ## Target user
 
@@ -26,85 +26,72 @@ Solo developer (initially: the author) who:
 
 ## Guiding metaphor
 
-**Issue tracking for a 5 year old.** A small number of buckets. An adult sorts new things into them. The 5 year old clears bullets when they're done.
+**A ranch you can see from the corner of your eye.** Pixel pig sprites roam the screen — one pig per Focus. They walk slowly. You don't have to look at them. But when you glance, you know what's on your ranch. Click a pig to see its tasks. Clear a task from that card. The pigs never interrupt; they just exist.
 
-## Goals (v1)
+## Goals (v1.2)
 
-1. Always-visible widget showing a short list of current Focuses, each with up to a few Tasks.
-2. Zero-friction capture: user runs `/checkpoint` in any Claude Code session; the in-session agent decides what bucket the moment belongs to and proposes an update.
-3. Human in the loop: every agent-suggested change is a *proposal* the user must accept.
-4. Hard caps (5 Focuses, 7 Tasks per Focus) with overload alerts when exceeded.
-5. Markdown is the source of truth — user can hand-edit any Focus file in any editor.
+1. Pixel pig sprites roam a fullscreen transparent overlay — one pig per Focus.
+2. Clicking a pig shows its name and Task list in a small popover. Tasks can be cleared from the popover.
+3. Manual Focus creation via menu bar item (simple native-style list). No agent flow in v1.2.
+4. Markdown is the source of truth — user can hand-edit any Focus file; pig count updates live via file watcher.
+5. Hard caps (5 Focuses, 7 Tasks per Focus) with overload alerts.
 
-## Non-goals (v1)
+## Non-goals (v1.2)
 
-- Mirroring Jira / GitHub. No external aggregators.
-- Auto-completion of Tasks (`complete_task` deferred).
-- Auto-merge of Focuses (`merge_focus` deferred).
+- Agent proposals / `/checkpoint` flow — deferred to v1.3.
+- Notification hook forwarding — deferred.
+- Auto-completion of Tasks (`complete_task`) — deferred.
+- Auto-merge of Focuses (`merge_focus`) — deferred.
 - Cross-platform (Linux/Windows). macOS only.
 - Multi-user / sync / cloud.
-- Token-economical automatic capture (no Stop hook capture; user-triggered only).
-- Notification hook forwarding ("Claude needs you" relay) — deferred to v1.x.
+- Fancy menu bar UI — native NSMenu list is sufficient.
 
 ## User stories
 
-- **US1.** As a developer with three Claude sessions running, I glance at my menubar and see three buckets: "Customer X bug", "API refactor", "Doc cleanup". Each bucket lists 2–4 plain-English bullets. I never need to wonder "wait, what was I doing in that other terminal?"
-- **US2.** Mid-session, I run `/checkpoint`. The agent reads my buckets, summarizes what we just did in one sentence, picks the right bucket, and submits a proposal. I tap accept in the widget. Done.
-- **US3.** I run `/checkpoint` on something that doesn't fit any bucket. The agent proposes a new Focus with a suggested title + description. I accept or edit the title.
-- **US4.** I finish a Task. I tap `✗` next to its bullet. Bullet disappears. No "are you sure".
-- **US5.** I add a Task by hand: open `~/.adhd-ranch/focuses/customer-x-bug/focus.md` in vim, append `- [ ] release staging`. Save. Widget reflects it within seconds.
-- **US6.** I have 6 Focuses open. The widget shows a red badge. macOS notification: "too much going on — trim 1". I delete a stale Focus.
+- **US1.** I glance at my screen and see three pixel pigs wandering in the corners. I know immediately: three things are on my plate. I don't have to open anything.
+- **US2.** I click a pig. A small dark card appears near the pig: its name and a short task list. I tap `✗` next to a task. It disappears. Card closes when I click elsewhere.
+- **US3.** I finish a Focus. I open the menu bar item, find it in the list, and delete it. Pig disappears from the screen.
+- **US4.** I add a Focus: click the menu bar item → "+ New Focus" → enter name + description. A new pig spawns and starts wandering.
+- **US5.** I hand-edit `~/.adhd-ranch/focuses/customer-x-bug/focus.md` in vim, append `- [ ] release staging`. Save. Pig's task list reflects it within seconds.
+- **US6.** I have 6 Focuses. The menu bar icon shows a red badge. I delete a stale Focus.
 
 ## Functional requirements
 
 ### FR1 — Focus storage
-Each Focus is a directory under `~/.adhd-ranch/focuses/<slug>/` containing `focus.md` with YAML frontmatter (`id`, `title`, `description`, `created_at`) and a body of `- [ ]` bullets. Plain text only.
+Unchanged. Each Focus is a directory under `~/.adhd-ranch/focuses/<slug>/` containing `focus.md` with YAML frontmatter (`id`, `title`, `description`, `created_at`) and a body of `- [ ]` bullets. Plain text only.
 
-### FR2 — Tauri menubar app
-- macOS tray icon via `TrayIconBuilder`.
-- Borderless, always-on-top popover positioned near the tray icon.
-- File watcher (`notify`) on `~/.adhd-ranch/focuses/`; UI re-renders on disk changes.
-- macOS system notifications via `tauri-plugin-notification`.
+### FR2 — Transparent overlay window
+- Full-screen transparent Tauri window: no decorations, always-on-top, covers the primary monitor.
+- Click-through when not hovering a pig: Rust polling thread reads `NSEvent.mouseLocation` every 16ms, compares against pig bounding boxes (sent from frontend), calls `window.set_ignore_cursor_events(!is_over_pig)`.
+- Pigs receive click events normally; transparent background passes clicks to whatever is beneath.
+- File watcher (`notify`) on `~/.adhd-ranch/focuses/`; pig count re-renders on disk changes.
 
-### FR3 — Widget UI
-Popover layout (top → bottom):
-1. List of Focuses, each with its Tasks. Each Task has inline `✗`. Each Focus has `…` → `Delete` (with confirm).
-2. "+ New Focus" button (always visible — also empty-state hero when no Focuses exist).
-3. Collapsed `📥 N pending` tray (badge with proposal count). Tap to expand.
-4. Expanded tray: per proposal, an inline card with summary + suggested target Focus + `✓ / ✗ / edit`. Reasoning hidden behind `?`.
+### FR3 — Pig UI
+- One `PigSprite` per Focus, positioned at the sprite's current (x, y) on the overlay.
+- Pigs wander the full screen: slow drift (~35 px/s), smooth random direction changes every 3–8 s, gentle boundary steering (40px margin from edges).
+- Animation: 4 frames per direction (left/right), ticked at ~150ms (≈6.7fps).
+- Sprite: real pixel-art sprite sheet when assets are ready (4 directions × 4 frames in one PNG); placeholder CSS/SVG pig until then.
+- Clicking a pig opens `PigDetail` popover near the pig (edge-clamped): Focus title + task list + `✗` per task.
+- `PigDetail` closes on click-outside.
 
-### FR4 — HTTP API
-Localhost-only, ephemeral port written to `~/.adhd-ranch/run/port`.
+### FR4 — Menu bar item
+- Tray icon in the macOS menu bar.
+- Native NSMenu with:
+  - List of current Focuses (each as a menu item showing title).
+  - Clicking a Focus item → brings the pig into view / opens its detail (TBD).
+  - Separator.
+  - "+ New Focus" → opens a small webview popover for title + description input.
+  - Separator.
+  - "Quit" → Cmd-Q.
+- Red badge on tray icon when over-cap.
 
-| Method | Path                       | Purpose                                              |
-|--------|----------------------------|------------------------------------------------------|
-| GET    | `/health`                  | liveness for clients                                 |
-| GET    | `/focuses`                 | catalog `[{id, title, description}]` for the agent   |
-| POST   | `/focuses`                 | create Focus `{title, description}`                  |
-| DELETE | `/focuses/{id}`            | remove Focus dir                                     |
-| POST   | `/focuses/{id}/tasks`      | append Task `{text}` (used by widget UI on accept)   |
-| DELETE | `/focuses/{id}/tasks/{idx}`| remove Task by 0-based bullet index                  |
-| POST   | `/proposals`               | enqueue proposal from `/checkpoint` agent            |
-| GET    | `/proposals`               | list pending proposals                               |
-| POST   | `/proposals/{id}/accept`   | accept; mutation applied; row appended to decisions  |
-| POST   | `/proposals/{id}/reject`   | reject; row appended to decisions                    |
-
-No auth.
-
-### FR5 — `/checkpoint` slash command
-- Installed at `~/.claude/commands/checkpoint.md` (global).
-- Reads port from `~/.adhd-ranch/run/port`. If missing or `/health` fails, errors clearly: "adhd-ranch not running, please start the app".
-- Instructs the in-session agent to:
-  1. `GET /focuses`.
-  2. Compose ONE sentence (≤ 12 words) summarizing the current work.
-  3. Decide kind: `add_task` | `new_focus` | `discard`.
-  4. `POST /proposals` with `{ kind, target_focus_id?, task_text?, new_focus?, summary, reasoning }`.
-- Single proposal per `/checkpoint`. Agent runs it again if multiple buckets affected.
+### FR5 — HTTP API
+Localhost-only, ephemeral port. Retained for `/checkpoint` flow (v1.3). No changes to routes.
 
 ### FR6 — Caps
 - `MAX_FOCUSES = 5`, `MAX_TASKS_PER_FOCUS = 7` (configurable in `settings.yaml`).
-- Writes that exceed caps still succeed (no hard rejection — markdown is canonical and user might edit anyway), but flip an over-cap flag.
-- Widget shows red badge while over.
+- Writes exceeding caps succeed but flip over-cap flag.
+- Tray icon shows red badge while over.
 - macOS notification fires once per `under → over` transition.
 
 ### FR7 — Configuration
@@ -115,58 +102,50 @@ caps:
   max_tasks_per_focus: 7
 alerts:
   system_notifications: true
+widget:
+  always_on_top: true
 ```
-Defaults applied for any missing keys.
 
 ### FR8 — Audit log
-Every accepted/rejected proposal appended to `~/.adhd-ranch/decisions.jsonl` with `{ts, proposal_id, decision, reasoning, target}`. Useful for tuning the routing prompt later.
+Retained. Every accepted/rejected proposal appended to `~/.adhd-ranch/decisions.jsonl`. Unused in v1.2 but preserved for v1.3.
 
 ## Non-functional requirements
 
-- **Latency:** widget reflects file changes within 1s of save. HTTP `POST /proposals` returns within 50ms.
-- **Reliability:** atomic writes (tmpfile + rename), per-file `flock`. No partial-write corruption visible to readers.
+- **Latency:** pig count reflects file changes within 1s of save.
+- **Click-through:** hit-test polling at ~60fps (16ms); transition latency < 32ms.
+- **Reliability:** atomic writes (tmpfile + rename), per-file `flock`. No partial-write corruption.
 - **Footprint:** Tauri release build < 20 MB on disk; idle RAM < 50 MB.
-- **Resilience:** if the app crashes, no markdown corruption (atomic writes); on relaunch the app reads from disk and resumes.
-- **Privacy:** zero outbound network. No telemetry, no LLM calls, no tickets posted anywhere.
+- **Privacy:** zero outbound network. No telemetry.
 
-## Success metrics (v1)
+## Success metrics (v1.2)
 
-This is a personal tool first. Metrics are subjective:
+- Author can name their active Focuses by glancing at the screen without opening any tool.
+- Pigs are visible and not disruptive — clicks pass through to other apps with < 32ms latency.
+- Click-a-pig → task card round trip feels instant (< 100ms perceived).
 
-- Author uses `/checkpoint` ≥ 5 times per work day for two weeks without abandoning.
-- Author can name their currently active Focuses without opening any other tool.
-- Routing accuracy ≥ 70% (proposals accepted as-is, no edit) — measured from `decisions.jsonl`.
-- Proposals are useful enough that the user prefers them to manually editing markdown for at least half the writes.
+## Out of scope / v1.3+
 
-If those hold, the bet pays. If not, the audit log gives labelled data to improve the prompt or fold in a Pass-2 routing call.
-
-## Out of scope / v2 ideas
-
+- `/checkpoint` slash command + agent proposal flow.
 - `merge_focus` and `complete_task` proposal kinds.
-- Notification-hook forwarding ("Claude needs you" badge).
-- Slash command for `/new-focus`.
-- `/usr/local/bin/adhd-ranch` symlink for shell shortcuts.
+- Menu bar Focus detail (clicking Focus in menu → highlight pig, open detail).
+- Notification-hook forwarding.
 - Linux + Windows ports.
 - External aggregators: Jira, GitHub, Linear.
-- Schema migrations (when frontmatter changes).
-- Rollup pass with separate LLM call (only if naive in-session routing proves insufficient).
-- Multi-machine sync (probably never — markdown in a synced dir like iCloud or git-managed dotfiles handles this for free).
+- Multi-machine sync.
 
 ## Open questions / risks
 
-- **R1.** Routing accuracy of a one-shot prompt may be poor when Focuses overlap conceptually. Mitigation: user can edit proposal target; audit log captures every miss for prompt tuning.
-- **R2.** The user might not run `/checkpoint` often enough. Mitigation: a future automatic/idle trigger can plug in via the same HTTP entrypoint without architectural change. Not v1.
-- **R3.** The 5/7 caps might feel too tight. Mitigation: configurable; trivial to bump.
-- **R4.** No real auth on the HTTP API. Any local process can write. Acceptable for a personal Mac; revisit if shared.
-- **R5.** `flock` semantics on macOS over network filesystems (iCloud Drive, NFS) are not perfect. Mitigation: keep `~/.adhd-ranch/` on local disk in v1; document.
+- **R1.** Click-through latency: 16ms Rust poll + IPC round-trip should feel transparent, but needs real-device testing.
+- **R2.** NSEvent.mouseLocation coordinate space: macOS uses bottom-left origin; CSS uses top-left. Must flip Y using screen height.
+- **R3.** Multiple monitors: pigs spawn on primary monitor only (v1.2). Multi-monitor layout deferred.
+- **R4.** Pig positions on resize: if screen resolution changes (external monitor connect/disconnect), pigs reset to safe positions.
+- **R5.** Always-on-top + fullscreen apps: at kCGFloatingWindowLevel (3), pigs disappear behind fullscreen apps. Acceptable for v1.2.
 
 ## Implementation phases
 
-1. **Phase 0 — Skeleton.** Tauri project, tray icon, popover window, empty `~/.adhd-ranch/` structure, hard-coded Focus list.
-2. **Phase 1 — Storage.** Markdown read/write, file watcher, schema parser, atomic writes, settings load.
-3. **Phase 2 — HTTP API.** All routes from FR4. Proposals queue. Accept/reject paths.
-4. **Phase 3 — Slash command.** `~/.claude/commands/checkpoint.md` with prompt template; manual end-to-end test.
-5. **Phase 4 — Caps + alerts.** Over-cap detection, system notifications, widget badge.
-6. **Phase 5 — Polish.** Edit-proposal modal, delete-Focus confirm, empty state, decisions audit log, packaging (`.app`, dmg).
-
-Each phase is independently testable. v1 ships at end of Phase 5.
+1. **Phase 0 (done):** Tauri skeleton, storage, HTTP API, markdown read/write, caps, file watcher, proposals queue.
+2. **Phase 1 (done):** Custom titlebar, app menu, always-on-top, regular Mac app.
+3. **Phase 2 — Pig overlay:** Transparent fullscreen window, click-through Rust polling thread, `PigSprite` placeholder, `usePigMovement`, `PigDetail` popover, `App.tsx` rewrite.
+4. **Phase 3 — Menu bar:** Tray icon, native NSMenu list, new-focus creation from tray, delete from tray.
+5. **Phase 4 — Real sprites:** Swap placeholder for real sprite sheet (4×4 grid PNG). Wire direction + frame to CSS background-position.
+6. **Phase 5 — Agent flow (v1.3):** Restore `/checkpoint` command + proposal queue UI (tray submenu or modal).

--- a/PRD.md
+++ b/PRD.md
@@ -58,15 +58,18 @@ Solo developer (initially: the author) who:
 ## Functional requirements
 
 ### FR1 — Focus storage
+
 Unchanged. Each Focus is a directory under `~/.adhd-ranch/focuses/<slug>/` containing `focus.md` with YAML frontmatter (`id`, `title`, `description`, `created_at`) and a body of `- [ ]` bullets. Plain text only.
 
 ### FR2 — Transparent overlay window
+
 - Full-screen transparent Tauri window: no decorations, always-on-top, covers the primary monitor.
 - Click-through when not hovering a pig: Rust polling thread reads `NSEvent.mouseLocation` every 16ms, compares against pig bounding boxes (sent from frontend), calls `window.set_ignore_cursor_events(!is_over_pig)`.
 - Pigs receive click events normally; transparent background passes clicks to whatever is beneath.
 - File watcher (`notify`) on `~/.adhd-ranch/focuses/`; pig count re-renders on disk changes.
 
 ### FR3 — Pig UI
+
 - One `PigSprite` per Focus, positioned at the sprite's current (x, y) on the overlay.
 - Pigs wander the full screen: slow drift (~35 px/s), smooth random direction changes every 3–8 s, gentle boundary steering (40px margin from edges).
 - Animation: 4 frames per direction (left/right), ticked at ~150ms (≈6.7fps).
@@ -75,6 +78,7 @@ Unchanged. Each Focus is a directory under `~/.adhd-ranch/focuses/<slug>/` conta
 - `PigDetail` closes on click-outside.
 
 ### FR4 — Menu bar item
+
 - Tray icon in the macOS menu bar.
 - Native NSMenu with:
   - List of current Focuses (each as a menu item showing title).
@@ -86,15 +90,18 @@ Unchanged. Each Focus is a directory under `~/.adhd-ranch/focuses/<slug>/` conta
 - Red badge on tray icon when over-cap.
 
 ### FR5 — HTTP API
+
 Localhost-only, ephemeral port. Retained for `/checkpoint` flow (v1.3). No changes to routes.
 
 ### FR6 — Caps
+
 - `MAX_FOCUSES = 5`, `MAX_TASKS_PER_FOCUS = 7` (configurable in `settings.yaml`).
 - Writes exceeding caps succeed but flip over-cap flag.
 - Tray icon shows red badge while over.
 - macOS notification fires once per `under → over` transition.
 
 ### FR7 — Configuration
+
 `~/.adhd-ranch/settings.yaml`:
 ```yaml
 caps:
@@ -107,6 +114,7 @@ widget:
 ```
 
 ### FR8 — Audit log
+
 Retained. Every accepted/rejected proposal appended to `~/.adhd-ranch/decisions.jsonl`. Unused in v1.2 but preserved for v1.3.
 
 ## Non-functional requirements

--- a/issues/013-tray-icon-focus-list.md
+++ b/issues/013-tray-icon-focus-list.md
@@ -1,0 +1,54 @@
+# 013 — Tray icon + live focus list
+
+## Parent PRD
+
+`PRD.md` §FR4 (Menu bar item)
+
+## What to build
+
+Reinstate a macOS menu bar tray icon (removed in v1.1 per D1, now repurposed as the ranch control panel). The icon opens a native NSMenu that lists current Focuses and provides a Quit item. The menu rebuilds live whenever focuses change.
+
+- **Tray icon** (`src-tauri/src/app/tray.rs`, new):
+  - Install via `TrayIconBuilder` in `app::run()` setup.
+  - Left- or right-click opens the NSMenu (standard macOS tray behavior).
+  - Normal icon: the app's pig icon (or a placeholder until real assets exist).
+  - Over-cap icon: swapped to a red-badged variant via `TrayIcon::set_icon` on the `focuses-changed` + cap-check path.
+- **NSMenu contents** (built with `tauri::menu::MenuBuilder`):
+  ```
+  [Focus title 1]   ← MenuItemBuilder, disabled (no action yet — submenu comes in 014)
+  [Focus title 2]
+  …
+  ─
+  Quit              ← calls app.exit(0)
+  ```
+  Empty-state: show a single greyed-out "No focuses yet" item.
+- **Live rebuild**:
+  - Subscribe to the existing `FOCUSES_CHANGED_EVENT` from within setup.
+  - On each event, re-read the focus store and call `tray.set_menu(Some(new_menu))`.
+  - Over-cap check runs the existing `CapEvaluator` to decide whether to swap the icon.
+- **No tray popover window** — the overlay window launched at startup is the pig canvas; the tray is menu-only.
+
+## Completion promise
+
+On `main`, clicking the macOS menu bar pig icon shows a native dropdown listing all current Focus titles (updating live within 1s of any focus file change), with a Quit item at the bottom; the icon shows a red badge while any cap is exceeded.
+
+## Acceptance criteria
+
+- [ ] Tray icon appears in menu bar at app launch.
+- [ ] Clicking the icon opens a native macOS menu.
+- [ ] Menu lists one item per Focus using `focus.title`.
+- [ ] Empty state: single greyed-out "No focuses yet" item.
+- [ ] After adding or deleting a focus (via file or HTTP), the menu updates within 1s without restarting the app.
+- [ ] When over-cap, tray icon swaps to a red-badged variant.
+- [ ] "Quit" item exits the app cleanly.
+- [ ] No static mut, no global singletons, no module-level mutable state. TrayIcon handle managed via `app.manage()` or passed through setup closure.
+- [ ] `task check` green.
+
+## Blocked by
+
+None — can start immediately.
+
+## User stories addressed
+
+- US3 (list of focuses accessible without opening anything else)
+- US6 (over-cap badge)

--- a/issues/013-tray-icon-focus-list.md
+++ b/issues/013-tray-icon-focus-list.md
@@ -14,13 +14,15 @@ Reinstate a macOS menu bar tray icon (removed in v1.1 per D1, now repurposed as 
   - Normal icon: the app's pig icon (or a placeholder until real assets exist).
   - Over-cap icon: swapped to a red-badged variant via `TrayIcon::set_icon` on the `focuses-changed` + cap-check path.
 - **NSMenu contents** (built with `tauri::menu::MenuBuilder`):
-  ```
+
+  ```text
   [Focus title 1]   ← MenuItemBuilder, disabled (no action yet — submenu comes in 014)
   [Focus title 2]
   …
   ─
   Quit              ← calls app.exit(0)
   ```
+
   Empty-state: show a single greyed-out "No focuses yet" item.
 - **Live rebuild**:
   - Subscribe to the existing `FOCUSES_CHANGED_EVENT` from within setup.

--- a/issues/014-new-focus-from-tray.md
+++ b/issues/014-new-focus-from-tray.md
@@ -1,0 +1,48 @@
+# 014 — New Focus from tray
+
+## Parent PRD
+
+`PRD.md` §FR4 (Menu bar item — "+ New Focus")
+
+## What to build
+
+Add a "+ New Focus" menu item to the tray NSMenu that opens a small, dedicated Tauri webview window containing the existing `NewFocusForm` component. On save the focus is created and the window closes; the pig spawns automatically via the file watcher.
+
+- **Tray menu change** (`src-tauri/src/app/tray.rs`):
+  - Prepend a `MenuItem` labelled "+ New Focus" above the focus list, separated by a `Separator`.
+  - On click: show the new-focus window (create if not yet created, show+focus if hidden).
+- **New-focus window** (`src-tauri/tauri.conf.json` + setup):
+  - Second Tauri webview window, label `"new-focus"`.
+  - Small fixed size: `320 × 180`, not resizable, `decorations: false`, `transparent: true`.
+  - Positioned near the tray icon (use `tauri-plugin-positioner` if already present, else center screen).
+  - `visible: false` at launch; shown on demand, hidden (not destroyed) after save or cancel.
+  - Renders a dedicated React route/component — reuse the existing `NewFocusForm` component with a submit handler that calls `create_focus` then hides the window.
+- **Frontend** (`src/components/NewFocusWindow.tsx`, new):
+  - Thin wrapper around `NewFocusForm` that calls `getCurrentWindow().hide()` after successful create.
+  - Mounts at `src/new-focus.tsx` (separate entry point so the main overlay bundle stays lean).
+  - Separate `new-focus.html` entry point in `tauri.conf.json`.
+- **No duplicate logic** — `create_focus` command unchanged; window just calls it.
+
+## Completion promise
+
+On `main`, clicking "+ New Focus" in the tray menu opens a small form window; filling in a title and submitting creates the focus (pig spawns on the overlay within 1s) and closes the form.
+
+## Acceptance criteria
+
+- [ ] "+ New Focus" item appears at the top of the tray menu.
+- [ ] Clicking it opens the new-focus window (small, no traffic lights).
+- [ ] Submitting a title creates the focus via the existing `create_focus` command.
+- [ ] The window closes (hides) after successful submit.
+- [ ] Cancelling (Escape or a Cancel button) hides the window without creating anything.
+- [ ] A new pig appears on the overlay within 1s of focus creation.
+- [ ] Submitting with an empty title shows an inline validation error (reuses existing `NewFocusForm` behaviour).
+- [ ] Second click on "+ New Focus" while window is already open brings it to front rather than creating a duplicate.
+- [ ] `task check` green.
+
+## Blocked by
+
+- `issues/013-tray-icon-focus-list.md`
+
+## User stories addressed
+
+- US4 (add a Focus via the menu)

--- a/issues/015-delete-focus-from-tray.md
+++ b/issues/015-delete-focus-from-tray.md
@@ -11,9 +11,11 @@ Each Focus item in the tray NSMenu gains a submenu. Hovering the Focus title rev
 - **Tray menu change** (`src-tauri/src/app/tray.rs`):
   - Replace each plain `MenuItem` for a focus with a `Submenu` whose title is the focus title.
   - Submenu contents:
-    ```
+
+    ```text
     Delete "Customer X bug"…
     ```
+
   - Menu item id carries the focus id so the event handler knows which focus to delete.
 - **Confirmation dialog**:
   - Use `tauri_plugin_dialog::blocking::confirm` (or the async variant) to show a native macOS sheet:
@@ -38,7 +40,7 @@ On `main`, hovering a Focus name in the tray menu reveals a submenu; clicking "D
 - [ ] Confirming deletes the focus directory and calls the existing `delete_focus` command path.
 - [ ] Cancelling does nothing.
 - [ ] Tray menu updates within 1s of deletion (pig also disappears from overlay).
-- [ ] No confirmation dialog if the user cancels.
+- [ ] No deletion occurs when the user cancels in the confirmation dialog.
 - [ ] `task check` green.
 
 ## Blocked by

--- a/issues/015-delete-focus-from-tray.md
+++ b/issues/015-delete-focus-from-tray.md
@@ -1,0 +1,50 @@
+# 015 — Delete Focus from tray
+
+## Parent PRD
+
+`PRD.md` §FR4 (Menu bar item — focus management)
+
+## What to build
+
+Each Focus item in the tray NSMenu gains a submenu. Hovering the Focus title reveals an arrow; the submenu contains a single "Delete…" item. Clicking "Delete…" shows a macOS native confirmation dialog; confirming calls `delete_focus` and the pig disappears from the overlay.
+
+- **Tray menu change** (`src-tauri/src/app/tray.rs`):
+  - Replace each plain `MenuItem` for a focus with a `Submenu` whose title is the focus title.
+  - Submenu contents:
+    ```
+    Delete "Customer X bug"…
+    ```
+  - Menu item id carries the focus id so the event handler knows which focus to delete.
+- **Confirmation dialog**:
+  - Use `tauri_plugin_dialog::blocking::confirm` (or the async variant) to show a native macOS sheet:
+    - Title: `Delete Focus?`
+    - Message: `"Customer X bug" will be permanently removed.`
+    - Buttons: Delete (destructive), Cancel.
+  - Only call `delete_focus` if the user confirms.
+- **After delete**:
+  - `delete_focus` command removes the focus directory.
+  - File watcher fires `focuses-changed`; tray menu rebuilds (from 012) and pig disappears (existing overlay behaviour).
+- **Plugin**: add `tauri-plugin-dialog` to `Cargo.toml` and `tauri.conf.json` capabilities if not already present.
+
+## Completion promise
+
+On `main`, hovering a Focus name in the tray menu reveals a submenu; clicking "Delete…" shows a native confirmation dialog; confirming removes the focus, updates the menu, and removes the pig from the overlay within 1s.
+
+## Acceptance criteria
+
+- [ ] Each Focus item in the tray menu has a submenu arrow.
+- [ ] Submenu contains "Delete \"{title}\"…" item.
+- [ ] Clicking it shows a native macOS confirmation dialog.
+- [ ] Confirming deletes the focus directory and calls the existing `delete_focus` command path.
+- [ ] Cancelling does nothing.
+- [ ] Tray menu updates within 1s of deletion (pig also disappears from overlay).
+- [ ] No confirmation dialog if the user cancels.
+- [ ] `task check` green.
+
+## Blocked by
+
+- `issues/013-tray-icon-focus-list.md`
+
+## User stories addressed
+
+- US3 (delete a stale Focus from the menu)

--- a/issues/016-real-sprite-sheet.md
+++ b/issues/016-real-sprite-sheet.md
@@ -1,0 +1,57 @@
+# 016 — Real pig sprite sheet
+
+## Parent PRD
+
+`PRD.md` §FR3 (Pig UI — sprite animation)
+
+## What to build
+
+Swap the placeholder 🐷 emoji in `PigSprite.tsx` for the real 4-direction × 4-frame pixel-art sprite sheet PNG. Wire CSS `background-position` to the current `direction` and `frame` props so pigs animate correctly as they walk.
+
+**HITL gate**: the user must supply the sprite sheet PNG and confirm the frame layout (dimensions per frame, row order for directions) before code changes begin.
+
+- **Asset placement**: drop the sprite sheet at `src/assets/pig-spritesheet.png`. Vite will bundle it and expose it as a hashed URL via `import pigSheet from '../assets/pig-spritesheet.png'`.
+- **Frame layout** (confirm with user before coding):
+  - Expected default: 4 rows × 4 columns. Row order: `down=0, left=1, right=2, up=3` (common RPG convention). Adjust if different.
+  - Frame width = `sheet_width / 4`, frame height = `sheet_height / 4`.
+- **`PigSprite.tsx` change** (the swap comment at lines 16–26 marks the exact location):
+  - Remove the `<span className="pig-emoji">` element.
+  - Replace with:
+    ```tsx
+    <div
+      className="pig-sprite-frame"
+      style={{
+        backgroundImage: `url(${pigSheet})`,
+        backgroundPosition: `-${frame * FRAME_W}px -${row * FRAME_H}px`,
+        width: FRAME_W,
+        height: FRAME_H,
+        imageRendering: "pixelated",
+      }}
+    />
+    ```
+  - `row` derived from `direction`: `left=1, right=2` (up/down unused in v1.2 — pigs only move in 2D horizontal plane for now).
+  - Remove `scaleX(-1)` transform from the button (direction handled by row selection instead).
+- **CSS**: add `.pig-sprite-frame { display: block; }`. Remove `.pig-emoji` rule.
+- **`PIG_SIZE`** in `usePigMovement.ts`: update to match `FRAME_H` (the sprite's actual pixel height × scale factor if rendering at 2×).
+
+## Completion promise
+
+On `main`, pigs render as pixel-art sprites from the real sprite sheet, walking left or right with correct frame animation, at the same hitbox size as the placeholder.
+
+## Acceptance criteria
+
+- [ ] User has provided the sprite sheet PNG and confirmed frame dimensions + row order. (HITL gate — must happen before code starts.)
+- [ ] Pigs display the sprite sheet frames instead of the emoji.
+- [ ] Walking right uses the correct sprite row; walking left uses a different row (not a CSS flip of right).
+- [ ] Animation cycles through 4 frames at ~150ms per frame.
+- [ ] `PIG_SIZE` in `usePigMovement.ts` matches the rendered sprite height so the Rust hit-test box aligns with the visible pig.
+- [ ] `imageRendering: pixelated` applied so sprites don't blur at display scale.
+- [ ] `task check` green.
+
+## Blocked by
+
+None (code-side). Requires user to supply sprite sheet asset before implementation begins.
+
+## User stories addressed
+
+- US1 (pigs are visually recognisable pixel-art animals, not emoji)

--- a/issues/016-real-sprite-sheet.md
+++ b/issues/016-real-sprite-sheet.md
@@ -17,6 +17,7 @@ Swap the placeholder 🐷 emoji in `PigSprite.tsx` for the real 4-direction × 4
 - **`PigSprite.tsx` change** (the swap comment at lines 16–26 marks the exact location):
   - Remove the `<span className="pig-emoji">` element.
   - Replace with:
+
     ```tsx
     <div
       className="pig-sprite-frame"
@@ -29,6 +30,7 @@ Swap the placeholder 🐷 emoji in `PigSprite.tsx` for the real 4-direction × 4
       }}
     />
     ```
+
   - `row` derived from `direction`: `left=1, right=2` (up/down unused in v1.2 — pigs only move in 2D horizontal plane for now).
   - Remove `scaleX(-1)` transform from the button (direction handled by row selection instead).
 - **CSS**: add `.pig-sprite-frame { display: block; }`. Remove `.pig-emoji` rule.

--- a/issues/done/012-pig-overlay.md
+++ b/issues/done/012-pig-overlay.md
@@ -1,0 +1,39 @@
+# 012 — Pig overlay (transparent fullscreen canvas + placeholder pigs)
+
+## Parent PRD
+
+`PRD.md` §FR2 (Transparent overlay window), §FR3 (Pig UI)
+
+## What was built
+
+Replaced the floating 400×600 widget with a transparent fullscreen overlay. Pixel pig sprites (placeholder 🐷 emoji) wander the screen — one per Focus. Clicking a pig shows its task list in a detail card. Click-through works for all non-pig screen areas via a Rust polling thread.
+
+## Completion promise
+
+On `main`, the app presents a fullscreen transparent overlay; one pig spawns per Focus and drifts slowly around the screen; clicking a pig shows a dark card with the Focus title and its tasks (each clearable with ✗); clicks on non-pig areas pass through to whatever app is underneath.
+
+## Acceptance criteria
+
+- [x] App window covers the primary monitor (sized to `current_monitor().size()` at startup).
+- [x] Window background is fully transparent — underlying apps are visible.
+- [x] Clicks on empty screen areas pass through to other apps (verified via `set_ignore_cursor_events`).
+- [x] Clicks on pig sprites are captured by the webview.
+- [x] Rust polling thread reads `AppHandle::cursor_position()` at ~60fps and toggles click-through.
+- [x] Frontend calls `update_pig_rects` Tauri command (every 4 rAF frames) to keep Rust hit-test boxes current.
+- [x] One pig per Focus; pig count updates within 1s of focus file change.
+- [x] Pigs drift slowly (~35 px/s) with random direction changes every 3–8s; boundary steering keeps them on-screen.
+- [x] Animation: 4 frames at ~150ms each; pig bobs slightly.
+- [x] Pig label shows Focus title (mirrored correctly when pig faces left).
+- [x] Clicking a pig opens `PigDetail` card near the pig (edge-clamped).
+- [x] `PigDetail` shows Focus title + task list with ✗ to clear each task.
+- [x] Clicking backdrop or pressing Escape closes `PigDetail`.
+- [x] `PigSprite.tsx` has a documented swap comment showing exactly where to drop the real sprite sheet.
+- [x] `task check` green.
+
+## Blocked by
+
+- `issues/done/011-app-menu-titlebar-always-on-top.md`
+
+## User stories addressed
+
+- US1, US2

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,8 +1,9 @@
 pub mod cap_notifier;
 pub mod menu;
 pub mod paths;
+pub mod pig_hittest;
+pub mod tray;
 pub mod window_always_on_top;
-pub mod window_autosave;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,6 +45,7 @@ pub fn run() {
             ui_bridge::append_task,
             ui_bridge::delete_task,
             ui_bridge::get_caps,
+            ui_bridge::update_pig_rects,
         ])
         .menu(move |handle| menu::build(handle, settings.widget.always_on_top));
 
@@ -86,11 +88,19 @@ pub fn run() {
 
         app.manage(ui_bridge::CommandsState(commands));
 
+        let tray_icon = tray::setup(app.handle(), store.clone(), settings)?;
+
         let focuses_watcher = install_change_handlers(
             &focuses_root,
             vec![
                 emit_event_handler(app.handle().clone(), FOCUSES_CHANGED_EVENT),
                 evaluate_caps_handler(evaluator.clone()),
+                tray::rebuild_handler(
+                    tray_icon.clone(),
+                    app.handle().clone(),
+                    store.clone(),
+                    settings,
+                ),
             ],
         )?;
         let proposals_watcher = install_change_handlers(
@@ -100,6 +110,7 @@ pub fn run() {
                 PROPOSALS_CHANGED_EVENT,
             )],
         )?;
+        app.manage(TrayHandle(tray_icon));
         app.manage(WatcherHandles {
             _focuses: focuses_watcher,
             _proposals: proposals_watcher,
@@ -108,10 +119,35 @@ pub fn run() {
         let server = install_http_server(store, queue, decision_log)?;
         app.manage(server);
 
+        let hittester = pig_hittest::PigHitTester::new();
+        app.manage(ui_bridge::PigHitState(hittester.clone()));
+
         if let Some(window) = app.get_webview_window("main") {
-            window_always_on_top::apply(&window, settings.widget.always_on_top);
-            window_autosave::apply(&window, "adhd-ranch-main");
+            if let Ok(Some(monitor)) = window.current_monitor() {
+                let size = monitor.size();
+                let pos = monitor.position();
+                let _ = window.set_size(tauri::PhysicalSize::new(size.width, size.height));
+                let _ = window.set_position(tauri::PhysicalPosition::new(pos.x, pos.y));
+            }
+
+            window_always_on_top::apply(&window, true);
             let _ = window.show();
+
+            let app_handle = app.handle().clone();
+            let window_clone = window.clone();
+            std::thread::spawn(move || {
+                let mut last_over = false;
+                loop {
+                    if let Ok(cursor) = app_handle.cursor_position() {
+                        let over = hittester.is_hit(cursor.x, cursor.y);
+                        if over != last_over {
+                            let _ = window_clone.set_ignore_cursor_events(!over);
+                            last_over = over;
+                        }
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(16));
+                }
+            });
         }
 
         Ok(())
@@ -144,6 +180,9 @@ fn load_settings(path: &std::path::Path) -> Settings {
         Err(_) => Settings::default(),
     }
 }
+
+#[allow(dead_code)]
+struct TrayHandle<R: tauri::Runtime>(tauri::tray::TrayIcon<R>);
 
 #[allow(dead_code)]
 struct WatcherHandles {

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -136,10 +136,20 @@ pub fn run() {
             let app_handle = app.handle().clone();
             let window_clone = window.clone();
             std::thread::spawn(move || {
+                // Start click-through immediately so background is passthrough before first poll.
+                let _ = window_clone.set_ignore_cursor_events(true);
                 let mut last_over = false;
                 loop {
                     if let Ok(cursor) = app_handle.cursor_position() {
-                        let over = hittester.is_hit(cursor.x, cursor.y);
+                        // cursor_position() is in global desktop coords; pig rects from the
+                        // frontend are in webview-local physical pixels. Subtract window origin.
+                        let origin = window_clone
+                            .outer_position()
+                            .map(|p| (p.x as f64, p.y as f64))
+                            .unwrap_or((0.0, 0.0));
+                        let local_x = cursor.x - origin.0;
+                        let local_y = cursor.y - origin.1;
+                        let over = hittester.is_hit(local_x, local_y);
                         if over != last_over {
                             let _ = window_clone.set_ignore_cursor_events(!over);
                             last_over = over;

--- a/src-tauri/src/app/pig_hittest.rs
+++ b/src-tauri/src/app/pig_hittest.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct PigRect {
+    pub x: f64,
+    pub y: f64,
+    pub size: f64,
+}
+
+#[derive(Clone)]
+pub struct PigHitTester {
+    rects: Arc<Mutex<Vec<PigRect>>>,
+}
+
+impl Default for PigHitTester {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PigHitTester {
+    pub fn new() -> Self {
+        Self {
+            rects: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    pub fn update(&self, rects: Vec<PigRect>) {
+        if let Ok(mut guard) = self.rects.lock() {
+            *guard = rects;
+        }
+    }
+
+    pub fn is_hit(&self, x: f64, y: f64) -> bool {
+        let Ok(guard) = self.rects.lock() else {
+            return false;
+        };
+        guard
+            .iter()
+            .any(|r| x >= r.x && x <= r.x + r.size && y >= r.y && y <= r.y + r.size)
+    }
+}

--- a/src-tauri/src/app/tray.rs
+++ b/src-tauri/src/app/tray.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use adhd_ranch_domain::{cap_state, Focus, Settings};
+use adhd_ranch_storage::FocusStore;
+use tauri::image::Image;
+use tauri::menu::{IsMenuItem, Menu, MenuItemBuilder, PredefinedMenuItem};
+use tauri::tray::{TrayIcon, TrayIconBuilder};
+use tauri::{AppHandle, Runtime};
+
+const QUIT_ID: &str = "tray-quit";
+const NO_FOCUSES_ID: &str = "tray-no-focuses";
+
+pub fn setup<R: Runtime>(
+    app: &AppHandle<R>,
+    store: Arc<dyn FocusStore>,
+    settings: Settings,
+) -> tauri::Result<TrayIcon<R>> {
+    let focuses = store.list().unwrap_or_default();
+    let menu = build_menu(app, &focuses)?;
+    let over_cap = cap_state(&focuses, settings.caps).any_over();
+
+    let mut builder = TrayIconBuilder::new()
+        .menu(&menu)
+        .show_menu_on_left_click(true)
+        .on_menu_event(|app, event| {
+            if event.id().0 == QUIT_ID {
+                app.exit(0);
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    let tray = builder.build(app)?;
+
+    if over_cap {
+        let _ = tray.set_icon(Some(red_icon()));
+    }
+
+    Ok(tray)
+}
+
+pub fn rebuild_handler<R: Runtime>(
+    tray: TrayIcon<R>,
+    handle: AppHandle<R>,
+    store: Arc<dyn FocusStore>,
+    settings: Settings,
+) -> Box<dyn Fn() + Send + 'static> {
+    Box::new(move || {
+        let focuses = store.list().unwrap_or_default();
+        if let Ok(menu) = build_menu(&handle, &focuses) {
+            let _ = tray.set_menu(Some(menu));
+        }
+        let over_cap = cap_state(&focuses, settings.caps).any_over();
+        if over_cap {
+            let _ = tray.set_icon(Some(red_icon()));
+        } else if let Some(icon) = handle.default_window_icon() {
+            let _ = tray.set_icon(Some(icon.clone()));
+        }
+    })
+}
+
+fn build_menu<R: Runtime>(handle: &AppHandle<R>, focuses: &[Focus]) -> tauri::Result<Menu<R>> {
+    let mut items: Vec<Box<dyn IsMenuItem<R>>> = Vec::new();
+
+    if focuses.is_empty() {
+        let item = MenuItemBuilder::with_id(NO_FOCUSES_ID, "No focuses yet")
+            .enabled(false)
+            .build(handle)?;
+        items.push(Box::new(item));
+    } else {
+        for (i, focus) in focuses.iter().enumerate() {
+            let item = MenuItemBuilder::with_id(format!("tray-focus-{i}"), &focus.title)
+                .enabled(false)
+                .build(handle)?;
+            items.push(Box::new(item));
+        }
+    }
+
+    let sep = PredefinedMenuItem::separator(handle)?;
+    let quit = MenuItemBuilder::with_id(QUIT_ID, "Quit").build(handle)?;
+    items.push(Box::new(sep));
+    items.push(Box::new(quit));
+
+    let item_refs: Vec<&dyn IsMenuItem<R>> = items.iter().map(|b| b.as_ref()).collect();
+    Menu::with_items(handle, &item_refs)
+}
+
+fn red_icon() -> Image<'static> {
+    const SIZE: u32 = 16;
+    let rgba: Vec<u8> = (0..SIZE * SIZE)
+        .flat_map(|_| [220u8, 38, 38, 255])
+        .collect();
+    Image::new_owned(rgba, SIZE, SIZE)
+}

--- a/src-tauri/src/app/tray.rs
+++ b/src-tauri/src/app/tray.rs
@@ -15,7 +15,13 @@ pub fn setup<R: Runtime>(
     store: Arc<dyn FocusStore>,
     settings: Settings,
 ) -> tauri::Result<TrayIcon<R>> {
-    let focuses = store.list().unwrap_or_default();
+    let focuses = match store.list() {
+        Ok(f) => f,
+        Err(e) => {
+            log::error!("tray setup: failed to read focuses: {e}");
+            Vec::new()
+        }
+    };
     let menu = build_menu(app, &focuses)?;
     let over_cap = cap_state(&focuses, settings.caps).any_over();
 
@@ -36,6 +42,8 @@ pub fn setup<R: Runtime>(
 
     if over_cap {
         let _ = tray.set_icon(Some(red_icon()));
+    } else if app.default_window_icon().is_none() {
+        let _ = tray.set_icon(None);
     }
 
     Ok(tray)
@@ -48,7 +56,13 @@ pub fn rebuild_handler<R: Runtime>(
     settings: Settings,
 ) -> Box<dyn Fn() + Send + 'static> {
     Box::new(move || {
-        let focuses = store.list().unwrap_or_default();
+        let focuses = match store.list() {
+            Ok(f) => f,
+            Err(e) => {
+                log::error!("tray rebuild: failed to read focuses: {e}");
+                return;
+            }
+        };
         if let Ok(menu) = build_menu(&handle, &focuses) {
             let _ = tray.set_menu(Some(menu));
         }
@@ -57,6 +71,8 @@ pub fn rebuild_handler<R: Runtime>(
             let _ = tray.set_icon(Some(red_icon()));
         } else if let Some(icon) = handle.default_window_icon() {
             let _ = tray.set_icon(Some(icon.clone()));
+        } else {
+            let _ = tray.set_icon(None);
         }
     })
 }

--- a/src-tauri/src/ui_bridge/mod.rs
+++ b/src-tauri/src/ui_bridge/mod.rs
@@ -9,8 +9,11 @@ use adhd_ranch_domain::{Caps, Focus, Proposal};
 use tauri::State;
 
 use crate::api::Health;
+use crate::app::pig_hittest::{PigHitTester, PigRect};
 
 pub struct CommandsState(pub Arc<Commands>);
+
+pub struct PigHitState(pub PigHitTester);
 
 #[tauri::command]
 pub fn health() -> Health {
@@ -124,4 +127,9 @@ pub fn create_proposal(
         .create_proposal(input)
         .inspect(|p| log::info!("proposal created: {}", p.id))
         .inspect_err(|e| log::error!("create_proposal: {e}"))
+}
+
+#[tauri::command]
+pub fn update_pig_rects(rects: Vec<PigRect>, state: State<'_, PigHitState>) {
+    state.0.update(rects);
 }

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,19 +1,38 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { createFixtureCapsReader } from "../api/caps";
 import { createFixtureFocusReader } from "../api/fixtureFocusReader";
-import { createFixtureProposalReader } from "../api/fixtureProposalReader";
 import type { FocusWriter } from "../api/focusWriter";
-import type { ProposalWriter } from "../api/proposals";
 import type { Focus } from "../types/focus";
 import { App } from "./App";
 
-const sample: Focus[] = [{ id: "a", title: "Customer X bug", description: "", tasks: [] }];
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
 
-const noopProposalWriter: ProposalWriter = {
-  accept: () => Promise.resolve({ id: "x", target: null }),
-  reject: () => Promise.resolve({ id: "x", target: null }),
-};
+vi.mock(import("../hooks/usePigMovement"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    usePigMovement: (focuses: readonly Focus[]) =>
+      focuses.map((f) => ({
+        id: f.id,
+        name: f.title,
+        x: 100,
+        y: 100,
+        vx: 1,
+        vy: 0,
+        frameIndex: 0,
+        direction: "right" as "left" | "right",
+        lastFrameAt: 0,
+        nextTurnAt: 9_999_999,
+      })),
+  };
+});
+
+const sample: Focus[] = [
+  { id: "a", title: "Customer X bug", description: "", tasks: [] },
+  { id: "b", title: "API refactor", description: "", tasks: [] },
+];
 
 function noopFocusWriter(): FocusWriter {
   return {
@@ -24,47 +43,17 @@ function noopFocusWriter(): FocusWriter {
   };
 }
 
-const baseCaps = { max_focuses: 5, max_tasks_per_focus: 7 };
-
-describe("App", () => {
-  it("renders root element and shows focuses once ready", async () => {
-    const focusReader = createFixtureFocusReader(sample);
-    const proposalReader = createFixtureProposalReader([]);
-    render(
-      <App
-        focusReader={focusReader}
-        focusWriter={noopFocusWriter()}
-        proposalReader={proposalReader}
-        proposalWriter={noopProposalWriter}
-        capsReader={createFixtureCapsReader(baseCaps)}
-      />,
-    );
-    expect(screen.getByTestId("app-root")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByText("Customer X bug")).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("cap-badge")).not.toBeInTheDocument();
+describe("App overlay", () => {
+  it("renders the overlay root", () => {
+    render(<App focusReader={createFixtureFocusReader([])} focusWriter={noopFocusWriter()} />);
+    expect(document.querySelector(".overlay-root")).toBeInTheDocument();
   });
 
-  it("shows the cap badge when over the focus limit", async () => {
-    const overFocuses: Focus[] = Array.from({ length: 6 }, (_, i) => ({
-      id: `f${i}`,
-      title: `F${i}`,
-      description: "",
-      tasks: [],
-    }));
-    render(
-      <App
-        focusReader={createFixtureFocusReader(overFocuses)}
-        focusWriter={noopFocusWriter()}
-        proposalReader={createFixtureProposalReader([])}
-        proposalWriter={noopProposalWriter}
-        capsReader={createFixtureCapsReader(baseCaps)}
-      />,
-    );
+  it("spawns a pig for each focus", async () => {
+    render(<App focusReader={createFixtureFocusReader(sample)} focusWriter={noopFocusWriter()} />);
     await waitFor(() => {
-      expect(screen.getByTestId("cap-badge")).toBeInTheDocument();
+      expect(screen.getByText("Customer X bug")).toBeInTheDocument();
+      expect(screen.getByText("API refactor")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("app-root")).toHaveAttribute("data-over-cap", "true");
   });
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,98 +1,49 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useState } from "react";
-import type { CapsReader } from "../api/caps";
 import type { FocusWriter } from "../api/focusWriter";
 import type { FocusReader } from "../api/focuses";
-import type { ProposalReader, ProposalWriter } from "../api/proposals";
-import { useAppState } from "../hooks/useAppState";
-import { computeCapState } from "../lib/capState";
-import { CapBadge } from "./CapBadge";
-import { FocusList } from "./FocusList";
-import { NewFocusForm } from "./NewFocusForm";
-import { PendingTray } from "./PendingTray";
-import { Titlebar } from "./Titlebar";
+import { useFocuses } from "../hooks/useFocuses";
+import { usePigMovement } from "../hooks/usePigMovement";
+import { PigDetail } from "./PigDetail";
+import { PigSprite } from "./PigSprite";
 
 export interface AppProps {
   readonly focusReader: FocusReader;
   readonly focusWriter: FocusWriter;
-  readonly proposalReader: ProposalReader;
-  readonly proposalWriter: ProposalWriter;
-  readonly capsReader: CapsReader;
 }
 
-export function App({
-  focusReader,
-  focusWriter,
-  proposalReader,
-  proposalWriter,
-  capsReader,
-}: AppProps) {
-  const state = useAppState({ focusReader, proposalReader, capsReader });
-  const [busyFocusId, setBusyFocusId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+export function App({ focusReader, focusWriter }: AppProps) {
+  const focusState = useFocuses(focusReader);
+  const focuses = focusState.status === "ready" ? focusState.focuses : [];
+  const pigs = usePigMovement(focuses);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const focusList = state.status === "ready" ? state.focuses : [];
-  const proposalList = state.status === "ready" ? state.proposals : [];
-  const capState = computeCapState(focusList, state.caps);
-
-  const wrap = async (focusId: string, run: () => Promise<unknown>) => {
-    setBusyFocusId(focusId);
-    setError(null);
-    try {
-      await run();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyFocusId((prev) => (prev === focusId ? null : prev));
-    }
-  };
-
-  const handleClearTask = (focusId: string, index: number) =>
-    wrap(focusId, () => focusWriter.deleteTask(focusId, index));
-
-  const handleDeleteFocus = (focusId: string) =>
-    wrap(focusId, () => focusWriter.deleteFocus(focusId));
-
-  const handleCreateFocus = async (input: { title: string; description: string }) => {
-    await focusWriter.createFocus(input);
-  };
-
-  const handleClose = () => {
-    void getCurrentWindow().hide();
-  };
+  const selectedPig = pigs.find((p) => p.id === selectedId);
+  const selectedFocus = focuses.find((f) => f.id === selectedId);
 
   return (
-    <div data-testid="app-root" className="app-root" data-over-cap={capState.anyOver}>
-      <Titlebar onClose={handleClose} />
-      <header className="app-header">
-        <h1 className="app-title">adhd-ranch</h1>
-        <CapBadge capState={capState} maxFocuses={state.caps.max_focuses} />
-      </header>
-      <main className="app-body">
-        {state.status === "loading" && <p data-testid="app-loading">Loading…</p>}
-        {state.status === "error" && (
-          <p data-testid="app-error" role="alert">
-            {state.error.message}
-          </p>
-        )}
-        {state.status === "ready" && (
-          <FocusList
-            focuses={state.focuses}
-            busyFocusId={busyFocusId}
-            onClearTask={handleClearTask}
-            onDeleteFocus={handleDeleteFocus}
-          />
-        )}
-        <NewFocusForm onCreate={handleCreateFocus} />
-        {error && (
-          <p data-testid="app-action-error" role="alert">
-            {error}
-          </p>
-        )}
-      </main>
-      <footer className="app-footer">
-        <PendingTray proposals={proposalList} focuses={focusList} proposalWriter={proposalWriter} />
-      </footer>
+    <div className="overlay-root">
+      {pigs.map((pig) => (
+        <PigSprite
+          key={pig.id}
+          x={pig.x}
+          y={pig.y}
+          direction={pig.direction}
+          frame={pig.frameIndex}
+          name={pig.name}
+          onClick={() => setSelectedId(pig.id)}
+        />
+      ))}
+      {selectedPig && selectedFocus && (
+        <PigDetail
+          focus={selectedFocus}
+          pigX={selectedPig.x}
+          pigY={selectedPig.y}
+          onClose={() => setSelectedId(null)}
+          onClearTask={(index) => {
+            void focusWriter.deleteTask(selectedFocus.id, index);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import type { FocusWriter } from "../api/focusWriter";
 import type { FocusReader } from "../api/focuses";
 import { useFocuses } from "../hooks/useFocuses";
 import { usePigMovement } from "../hooks/usePigMovement";
+import { useViewport } from "../hooks/useViewport";
 import { PigDetail } from "./PigDetail";
 import { PigSprite } from "./PigSprite";
 
@@ -15,10 +16,20 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const focusState = useFocuses(focusReader);
   const focuses = focusState.status === "ready" ? focusState.focuses : [];
   const pigs = usePigMovement(focuses);
+  const { screenW, screenH } = useViewport();
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const selectedPig = pigs.find((p) => p.id === selectedId);
   const selectedFocus = focuses.find((f) => f.id === selectedId);
+
+  async function handleClearTask(index: number) {
+    if (!selectedFocus) return;
+    try {
+      await focusWriter.deleteTask(selectedFocus.id, index);
+    } catch {
+      // focusWriter already logs the typed error
+    }
+  }
 
   return (
     <div className="overlay-root">
@@ -38,10 +49,10 @@ export function App({ focusReader, focusWriter }: AppProps) {
           focus={selectedFocus}
           pigX={selectedPig.x}
           pigY={selectedPig.y}
+          viewportW={screenW}
+          viewportH={screenH}
           onClose={() => setSelectedId(null)}
-          onClearTask={(index) => {
-            void focusWriter.deleteTask(selectedFocus.id, index);
-          }}
+          onClearTask={handleClearTask}
         />
       )}
     </div>

--- a/src/components/PigDetail.tsx
+++ b/src/components/PigDetail.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { PIG_SIZE } from "../hooks/usePigMovement";
 import type { Focus } from "../types/focus";
 
@@ -5,6 +6,8 @@ export interface PigDetailProps {
   readonly focus: Focus;
   readonly pigX: number;
   readonly pigY: number;
+  readonly viewportW: number;
+  readonly viewportH: number;
   readonly onClose: () => void;
   readonly onClearTask: (index: number) => void;
 }
@@ -12,20 +15,35 @@ export interface PigDetailProps {
 const CARD_W = 210;
 const CARD_OFFSET_X = PIG_SIZE + 8;
 
-export function PigDetail({ focus, pigX, pigY, onClose, onClearTask }: PigDetailProps) {
-  const screenW = window.screen.width;
-  const screenH = window.screen.height;
+export function PigDetail({
+  focus,
+  pigX,
+  pigY,
+  viewportW,
+  viewportH,
+  onClose,
+  onClearTask,
+}: PigDetailProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
 
   const rawX = pigX + CARD_OFFSET_X;
-  const x = Math.min(rawX, screenW - CARD_W - 16);
-  const y = Math.max(16, Math.min(pigY, screenH - 200));
+  const x = Math.min(rawX, viewportW - CARD_W - 16);
+  const y = Math.max(16, Math.min(pigY, viewportH - 200));
 
   return (
     <>
       <div
         className="pig-detail-backdrop"
         onClick={onClose}
-        onKeyDown={(e) => e.key === "Escape" && onClose()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
         role="presentation"
       />
       <div className="pig-detail" style={{ left: x, top: y, width: CARD_W }}>

--- a/src/components/PigDetail.tsx
+++ b/src/components/PigDetail.tsx
@@ -1,0 +1,55 @@
+import { PIG_SIZE } from "../hooks/usePigMovement";
+import type { Focus } from "../types/focus";
+
+export interface PigDetailProps {
+  readonly focus: Focus;
+  readonly pigX: number;
+  readonly pigY: number;
+  readonly onClose: () => void;
+  readonly onClearTask: (index: number) => void;
+}
+
+const CARD_W = 210;
+const CARD_OFFSET_X = PIG_SIZE + 8;
+
+export function PigDetail({ focus, pigX, pigY, onClose, onClearTask }: PigDetailProps) {
+  const screenW = window.screen.width;
+  const screenH = window.screen.height;
+
+  const rawX = pigX + CARD_OFFSET_X;
+  const x = Math.min(rawX, screenW - CARD_W - 16);
+  const y = Math.max(16, Math.min(pigY, screenH - 200));
+
+  return (
+    <>
+      <div
+        className="pig-detail-backdrop"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === "Escape" && onClose()}
+        role="presentation"
+      />
+      <div className="pig-detail" style={{ left: x, top: y, width: CARD_W }}>
+        <h3 className="pig-detail-title">{focus.title}</h3>
+        {focus.tasks.length === 0 ? (
+          <p className="pig-detail-empty">No tasks yet.</p>
+        ) : (
+          <ul className="pig-detail-tasks">
+            {focus.tasks.map((task, index) => (
+              <li key={task.id} className="pig-detail-task">
+                <span className="pig-detail-task-text">{task.text}</span>
+                <button
+                  type="button"
+                  className="pig-detail-task-clear"
+                  onClick={() => onClearTask(index)}
+                  aria-label={`clear task: ${task.text}`}
+                >
+                  ✗
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/PigSprite.tsx
+++ b/src/components/PigSprite.tsx
@@ -1,0 +1,49 @@
+export interface PigSpriteProps {
+  readonly x: number;
+  readonly y: number;
+  readonly direction: "left" | "right";
+  readonly frame: number;
+  readonly name: string;
+  readonly onClick: () => void;
+}
+
+// Placeholder pig: emoji + name label.
+// When real sprite sheet is ready, replace the inner div with:
+//   <div
+//     className="pig-sprite-frame"
+//     style={{
+//       backgroundImage: `url(/assets/pig-spritesheet.png)`,
+//       backgroundPosition: `-${frame * FRAME_W}px -${row * FRAME_H}px`,
+//       width: FRAME_W,
+//       height: FRAME_H,
+//       imageRendering: "pixelated",
+//     }}
+//   />
+// where row = direction === "left" ? 1 : 2 (adjust to match your sheet layout).
+const BOB_OFFSETS = [0, -2, 0, -1];
+
+export function PigSprite({ x, y, direction, frame, name, onClick }: PigSpriteProps) {
+  const bob = BOB_OFFSETS[frame % BOB_OFFSETS.length];
+  return (
+    <button
+      type="button"
+      className="pig-sprite"
+      style={{
+        left: x,
+        top: y + bob,
+        transform: direction === "left" ? "scaleX(-1)" : undefined,
+      }}
+      onClick={onClick}
+    >
+      <span className="pig-emoji" aria-hidden="true">
+        🐷
+      </span>
+      <span
+        className="pig-name"
+        style={{ transform: direction === "left" ? "scaleX(-1)" : undefined }}
+      >
+        {name}
+      </span>
+    </button>
+  );
+}

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -1,0 +1,152 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useRef, useState } from "react";
+import type { Focus } from "../types/focus";
+
+export const PIG_SIZE = 48;
+
+const PIG_SPEED = 35; // px/s
+const EDGE_MARGIN = 60; // px from screen edge
+const FRAME_INTERVAL = 150; // ms per animation frame
+const MIN_TURN_MS = 3000;
+const MAX_TURN_MS = 8000;
+const RECT_UPDATE_EVERY = 4; // rAF frames between pig-rect syncs to Rust
+
+export interface PigState {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  frameIndex: number;
+  direction: "left" | "right";
+  lastFrameAt: number;
+  nextTurnAt: number;
+}
+
+function randomTurnDelay(): number {
+  return MIN_TURN_MS + Math.random() * (MAX_TURN_MS - MIN_TURN_MS);
+}
+
+function initPig(focus: Focus, screenW: number, screenH: number, now: number): PigState {
+  const angle = Math.random() * 2 * Math.PI;
+  const vx = Math.cos(angle) * PIG_SPEED;
+  const vy = Math.sin(angle) * PIG_SPEED;
+  return {
+    id: focus.id,
+    name: focus.title,
+    x: EDGE_MARGIN + Math.random() * (screenW - 2 * EDGE_MARGIN - PIG_SIZE),
+    y: EDGE_MARGIN + Math.random() * (screenH - 2 * EDGE_MARGIN - PIG_SIZE),
+    vx,
+    vy,
+    frameIndex: 0,
+    direction: vx >= 0 ? "right" : "left",
+    lastFrameAt: now,
+    nextTurnAt: now + randomTurnDelay(),
+  };
+}
+
+function tickPig(
+  pig: PigState,
+  dt: number,
+  now: number,
+  screenW: number,
+  screenH: number,
+): PigState {
+  let { x, y, vx, vy, frameIndex, lastFrameAt, nextTurnAt, direction } = pig;
+
+  // Random direction change
+  if (now >= nextTurnAt) {
+    const angle = Math.random() * 2 * Math.PI;
+    vx = Math.cos(angle) * PIG_SPEED;
+    vy = Math.sin(angle) * PIG_SPEED;
+    nextTurnAt = now + randomTurnDelay();
+  }
+
+  // Soft boundary steering: blend away-from-edge velocity when within margin
+  if (x < EDGE_MARGIN) vx = Math.abs(vx) || PIG_SPEED * 0.5;
+  if (x > screenW - EDGE_MARGIN - PIG_SIZE) vx = -(Math.abs(vx) || PIG_SPEED * 0.5);
+  if (y < EDGE_MARGIN) vy = Math.abs(vy) || PIG_SPEED * 0.5;
+  if (y > screenH - EDGE_MARGIN - PIG_SIZE) vy = -(Math.abs(vy) || PIG_SPEED * 0.5);
+
+  // Clamp speed
+  const speed = Math.sqrt(vx * vx + vy * vy);
+  if (speed > PIG_SPEED * 1.2) {
+    vx = (vx / speed) * PIG_SPEED;
+    vy = (vy / speed) * PIG_SPEED;
+  }
+
+  // Update position, hard-clamp to screen
+  x = Math.max(0, Math.min(screenW - PIG_SIZE, x + vx * (dt / 1000)));
+  y = Math.max(0, Math.min(screenH - PIG_SIZE, y + vy * (dt / 1000)));
+
+  direction = vx >= 0 ? "right" : "left";
+
+  if (now - lastFrameAt >= FRAME_INTERVAL) {
+    frameIndex = (frameIndex + 1) % 4;
+    lastFrameAt = now;
+  }
+
+  return { ...pig, x, y, vx, vy, frameIndex, direction, lastFrameAt, nextTurnAt };
+}
+
+function syncRects(pigs: PigState[]): void {
+  const dpr = window.devicePixelRatio || 1;
+  const rects = pigs.map((p) => ({
+    x: p.x * dpr,
+    y: p.y * dpr,
+    size: PIG_SIZE * dpr,
+  }));
+  invoke("update_pig_rects", { rects }).catch(() => {
+    // Silently ignore when running outside Tauri (e.g., browser dev)
+  });
+}
+
+export function usePigMovement(focuses: readonly Focus[]): PigState[] {
+  const [pigs, setPigs] = useState<PigState[]>([]);
+  const pigsRef = useRef<PigState[]>([]);
+  const rafRef = useRef<number>(0);
+  const lastTimeRef = useRef<number>(performance.now());
+  const frameCountRef = useRef<number>(0);
+
+  // Sync pig list to focuses: add spawns for new, remove for deleted.
+  useEffect(() => {
+    const screenW = window.screen.width;
+    const screenH = window.screen.height;
+    const now = performance.now();
+
+    setPigs((prev) => {
+      const prevMap = new Map(prev.map((p) => [p.id, p]));
+      const next = focuses.map((f) => prevMap.get(f.id) ?? initPig(f, screenW, screenH, now));
+      pigsRef.current = next;
+      return next;
+    });
+  }, [focuses]);
+
+  // rAF movement loop
+  useEffect(() => {
+    const loop = (now: number) => {
+      const dt = Math.min(now - lastTimeRef.current, 100);
+      lastTimeRef.current = now;
+
+      const screenW = window.screen.width;
+      const screenH = window.screen.height;
+
+      const updated = pigsRef.current.map((p) => tickPig(p, dt, now, screenW, screenH));
+      pigsRef.current = updated;
+      setPigs(updated);
+
+      frameCountRef.current += 1;
+      if (frameCountRef.current % RECT_UPDATE_EVERY === 0) {
+        syncRects(updated);
+      }
+
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  return pigs;
+}

--- a/src/hooks/useViewport.ts
+++ b/src/hooks/useViewport.ts
@@ -1,0 +1,3 @@
+export function useViewport() {
+  return { screenW: window.screen.width, screenH: window.screen.height };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createTauriCapsReader } from "./api/caps";
 import { createTauriFocusWriter } from "./api/focusWriter";
 import { createTauriFocusReader } from "./api/tauriFocusReader";
-import { createTauriProposalReader, createTauriProposalWriter } from "./api/tauriProposalReader";
 import { App } from "./components/App";
 import "./styles.css";
 
@@ -12,18 +10,9 @@ if (!rootEl) throw new Error("missing #root");
 
 const focusReader = createTauriFocusReader();
 const focusWriter = createTauriFocusWriter();
-const proposalReader = createTauriProposalReader();
-const proposalWriter = createTauriProposalWriter();
-const capsReader = createTauriCapsReader();
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App
-      focusReader={focusReader}
-      focusWriter={focusWriter}
-      proposalReader={proposalReader}
-      proposalWriter={proposalWriter}
-      capsReader={capsReader}
-    />
+    <App focusReader={focusReader} focusWriter={focusWriter} />
   </React.StrictMode>,
 );

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,19 +13,17 @@ body,
 #root {
   margin: 0;
   padding: 0;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   background: transparent;
+  overflow: hidden;
 }
 
-.app-root {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  border-radius: 12px;
-  background: rgba(28, 28, 30, 0.95);
-  color: #f5f5f7;
-  padding: 12px;
-  overflow: hidden;
+.overlay-root {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: transparent;
 }
 
 .titlebar {
@@ -385,4 +383,107 @@ body,
   cursor: pointer;
   padding: 2px 8px;
   font-size: 12px;
+}
+
+/* ── Pig overlay ──────────────────────────────────────────── */
+
+.pig-sprite {
+  position: absolute;
+  pointer-events: auto;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  user-select: none;
+}
+
+.pig-emoji {
+  font-size: 32px;
+  line-height: 1;
+  display: block;
+}
+
+.pig-name {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8), 0 0 6px rgba(0, 0, 0, 0.6);
+  white-space: nowrap;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pig-detail-backdrop {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+  background: transparent;
+}
+
+.pig-detail {
+  position: absolute;
+  pointer-events: auto;
+  background: rgba(28, 28, 30, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #f5f5f7;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+.pig-detail-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pig-detail-empty {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+.pig-detail-tasks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pig-detail-task {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.pig-detail-task-text {
+  font-size: 12px;
+  opacity: 0.9;
+  flex: 1;
+}
+
+.pig-detail-task-clear {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 12px;
+  opacity: 0.5;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
+.pig-detail-task-clear:hover {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary

- Transparent fullscreen overlay window (always-on-top, no decorations) renders one pixel-pig per Focus
- Pigs wander at ~35px/s with soft boundary steering, random direction changes, and 4-frame walk animation
- Click-through: Rust polling thread (16ms) reads pig bounding boxes synced from frontend every 4 rAF frames; toggles `set_ignore_cursor_events` so only pig-area clicks register
- Tray icon: live focus list, red badge when over-cap, rebuilds within 1s via the `focuses-changed` watcher fan-out; Quit item exits cleanly
- `PigDetail` card opens near clicked pig: shows focus title + tasks with delete buttons; click-outside closes

## Issues

Closes #6 (013 — tray icon + live focus list)
Delivers 012 (pig overlay)

## Test plan

- [ ] `task check` green
- [ ] Pigs appear on screen at launch, one per focus
- [ ] Pigs wander; click-through works on transparent background; clicking a pig opens detail card
- [ ] Tray icon appears; menu lists focuses; updates within 1s after adding/removing a focus via HTTP or file edit
- [ ] Red badge appears when focus count exceeds cap
- [ ] Quit exits the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transparent fullscreen overlay with animated wandering pigs—one per Focus
  * Click a pig to open a detail card showing tasks (clear tasks, backdrop/Escape to close)
  * System tray/menu lists Focuses with a “+ New Focus” flow and Delete via confirmation
  * Tray icon indicates over-capacity with a red badge/icon
  * Overlay kept always-on-top and remains click-through outside pig areas
<!-- end of auto-generated comment: release notes by coderabbit.ai -->