### PR TITLE
feat: 014 — new focus from tray

### DIFF
--- a/new-focus.html
+++ b/new-focus.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>New Focus</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/new-focus.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tauri-apps/cli": "^2.1.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
+        "@types/node": "^25.6.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1852,6 +1853,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -3304,6 +3315,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/cli": "^2.1.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@types/node": "^25.6.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default capabilities for adhd-ranch",
-  "windows": ["main"],
+  "windows": ["main", "new-focus"],
   "permissions": [
     "core:default",
     "core:window:allow-show",

--- a/src-tauri/src/app/tray.rs
+++ b/src-tauri/src/app/tray.rs
@@ -9,6 +9,7 @@ use tauri::{AppHandle, Manager, Runtime};
 
 const QUIT_ID: &str = "tray-quit";
 const NO_FOCUSES_ID: &str = "tray-no-focuses";
+const NEW_FOCUS_ID: &str = "tray-new-focus";
 const DELETE_PREFIX: &str = "tray-delete-";
 
 pub fn setup<R: Runtime>(
@@ -33,6 +34,11 @@ pub fn setup<R: Runtime>(
             let id = event.id().0.as_str();
             if id == QUIT_ID {
                 app.exit(0);
+            } else if id == NEW_FOCUS_ID {
+                if let Some(win) = app.get_webview_window("new-focus") {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
             } else if let Some(focus_id) = id.strip_prefix(DELETE_PREFIX) {
                 let focus_id = focus_id.to_string();
                 let app_handle = app.clone();
@@ -85,6 +91,10 @@ pub fn rebuild_handler<R: Runtime>(
 
 fn build_menu<R: Runtime>(handle: &AppHandle<R>, focuses: &[Focus]) -> tauri::Result<Menu<R>> {
     let mut items: Vec<Box<dyn IsMenuItem<R>>> = Vec::new();
+
+    let new_focus = MenuItemBuilder::with_id(NEW_FOCUS_ID, "+ New Focus").build(handle)?;
+    items.push(Box::new(new_focus));
+    items.push(Box::new(PredefinedMenuItem::separator(handle)?));
 
     if focuses.is_empty() {
         let item = MenuItemBuilder::with_id(NO_FOCUSES_ID, "No focuses yet")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,19 @@
         "resizable": true,
         "transparent": true,
         "visible": false
+      },
+      {
+        "label": "new-focus",
+        "url": "new-focus.html",
+        "title": "New Focus",
+        "width": 320,
+        "height": 180,
+        "minWidth": 320,
+        "minHeight": 180,
+        "decorations": false,
+        "resizable": false,
+        "transparent": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src/components/NewFocusWindow.tsx
+++ b/src/components/NewFocusWindow.tsx
@@ -1,57 +1,32 @@
-import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useEffect, useState } from "react";
+export interface NewFocusWindowProps {
+  readonly title: string;
+  readonly description: string;
+  readonly submitting: boolean;
+  readonly error: string | null;
+  readonly onTitleChange: (v: string) => void;
+  readonly onDescriptionChange: (v: string) => void;
+  readonly onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  readonly onCancel: () => void;
+}
 
-export function NewFocusWindow() {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") void hideWindow();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
-
-  const hideWindow = async () => {
-    setTitle("");
-    setDescription("");
-    setError(null);
-    await getCurrentWindow().hide();
-  };
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (title.trim().length === 0) {
-      setError("title is required");
-      return;
-    }
-    setSubmitting(true);
-    setError(null);
-    try {
-      await invoke("create_focus", {
-        title: title.trim(),
-        description: description.trim() || null,
-      });
-      await hideWindow();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
+export function NewFocusWindow({
+  title,
+  description,
+  submitting,
+  error,
+  onTitleChange,
+  onDescriptionChange,
+  onSubmit,
+  onCancel,
+}: NewFocusWindowProps) {
   return (
-    <form className="new-focus-form" onSubmit={handleSubmit}>
+    <form className="new-focus-form" onSubmit={onSubmit}>
       <input
         type="text"
         placeholder="Title"
         aria-label="new focus title"
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => onTitleChange(e.target.value)}
         disabled={submitting}
         // biome-ignore lint/a11y/noAutofocus: first field in a small dedicated window
         autoFocus
@@ -61,14 +36,14 @@ export function NewFocusWindow() {
         placeholder="Description"
         aria-label="new focus description"
         value={description}
-        onChange={(e) => setDescription(e.target.value)}
+        onChange={(e) => onDescriptionChange(e.target.value)}
         disabled={submitting}
       />
       <div className="new-focus-actions">
         <button type="submit" disabled={submitting}>
           Create
         </button>
-        <button type="button" onClick={() => void hideWindow()} disabled={submitting}>
+        <button type="button" onClick={onCancel} disabled={submitting}>
           Cancel
         </button>
       </div>

--- a/src/components/NewFocusWindow.tsx
+++ b/src/components/NewFocusWindow.tsx
@@ -1,0 +1,82 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+
+export function NewFocusWindow() {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") void hideWindow();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const hideWindow = async () => {
+    setTitle("");
+    setDescription("");
+    setError(null);
+    await getCurrentWindow().hide();
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (title.trim().length === 0) {
+      setError("title is required");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await invoke("create_focus", {
+        title: title.trim(),
+        description: description.trim() || null,
+      });
+      await hideWindow();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="new-focus-form" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        placeholder="Title"
+        aria-label="new focus title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        disabled={submitting}
+        // biome-ignore lint/a11y/noAutofocus: first field in a small dedicated window
+        autoFocus
+      />
+      <input
+        type="text"
+        placeholder="Description"
+        aria-label="new focus description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        disabled={submitting}
+      />
+      <div className="new-focus-actions">
+        <button type="submit" disabled={submitting}>
+          Create
+        </button>
+        <button type="button" onClick={() => void hideWindow()} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+      {error && (
+        <p data-testid="new-focus-error" role="alert" className="new-focus-error">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/src/hooks/useNewFocusWindow.ts
+++ b/src/hooks/useNewFocusWindow.ts
@@ -1,0 +1,74 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+import type { FocusWriter } from "../api/focusWriter";
+
+export interface NewFocusWindowState {
+  readonly title: string;
+  readonly description: string;
+  readonly submitting: boolean;
+  readonly error: string | null;
+  readonly setTitle: (v: string) => void;
+  readonly setDescription: (v: string) => void;
+  readonly handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+  readonly handleCancel: () => Promise<void>;
+}
+
+export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hideWindow = async () => {
+    setTitle("");
+    setDescription("");
+    setError(null);
+    await getCurrentWindow().hide();
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setTitle("");
+        setDescription("");
+        setError(null);
+        void getCurrentWindow().hide();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (title.trim().length === 0) {
+      setError("title is required");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await focusWriter.createFocus({ title: title.trim(), description: description.trim() });
+      await hideWindow();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    await hideWindow();
+  };
+
+  return {
+    title,
+    description,
+    submitting,
+    error,
+    setTitle,
+    setDescription,
+    handleSubmit,
+    handleCancel,
+  };
+}

--- a/src/new-focus.tsx
+++ b/src/new-focus.tsx
@@ -1,13 +1,43 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { createTauriFocusWriter } from "./api/focusWriter";
 import { NewFocusWindow } from "./components/NewFocusWindow";
+import { useNewFocusWindow } from "./hooks/useNewFocusWindow";
 import "./styles.css";
+
+const focusWriter = createTauriFocusWriter();
+
+function NewFocusApp() {
+  const {
+    title,
+    description,
+    submitting,
+    error,
+    setTitle,
+    setDescription,
+    handleSubmit,
+    handleCancel,
+  } = useNewFocusWindow(focusWriter);
+
+  return (
+    <NewFocusWindow
+      title={title}
+      description={description}
+      submitting={submitting}
+      error={error}
+      onTitleChange={setTitle}
+      onDescriptionChange={setDescription}
+      onSubmit={handleSubmit}
+      onCancel={() => void handleCancel()}
+    />
+  );
+}
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("missing #root");
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <NewFocusWindow />
+    <NewFocusApp />
   </React.StrictMode>,
 );

--- a/src/new-focus.tsx
+++ b/src/new-focus.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { NewFocusWindow } from "./components/NewFocusWindow";
+import "./styles.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing #root");
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <NewFocusWindow />
+  </React.StrictMode>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
-import { resolve } from "path";
-import { defineConfig } from "vite";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -7,6 +8,14 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        newFocus: resolve(__dirname, "new-focus.html"),
+      },
+    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

- Adds "+ New Focus" item at top of tray NSMenu (above focus list, separated by a divider)
- Clicking opens a dedicated 320×180 `new-focus` WebviewWindow (`decorations: false`, `transparent: true`, `visible: false` at launch)
- Second click while window is already open brings it to front without creating a duplicate
- Form submits via existing `create_focus` Tauri command; window hides on success
- Escape key or Cancel button hides without creating

## Implementation notes

- `new-focus.html` / `src/new-focus.tsx` — separate Vite entry point so main overlay bundle stays lean
- `NewFocusWindow` — always-visible form (no toggle button), resets state on submit/cancel
- Vite `rollupOptions.input` for multi-page production build
- `@types/node` added (devDep) for `path.resolve` in vite config
- `capabilities/default.json`: `new-focus` window added to windows list

## Test plan

- [ ] `task check` green (CI)
- [ ] Open tray → "+ New Focus" appears at top
- [ ] Click it → small form window opens
- [ ] Fill title, submit → focus created, pig spawns within 1s, window closes
- [ ] Empty title → inline error, no close
- [ ] Cancel or Escape → window hides, nothing created
- [ ] Click "+ New Focus" while window open → window brought to front, not duplicated

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact "New Focus" window (small, fixed size, transparent) to create focus items with title and optional description.
  * Accessible from the system tray via a "+ New Focus" menu item; window opens and gains focus when selected.
  * Press Escape to close the window and clear input/error state.

* **Chores**
  * Build updated to include the new window entry and entry point.
* **Dependencies**
  * Added a dev dependency for type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->