### PR TITLE
feat: 015 — delete focus from tray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "time",
@@ -3420,6 +3421,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4218,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5370,6 +5437,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5416,11 +5492,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5460,6 +5553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5476,6 +5575,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5496,10 +5601,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5520,6 +5637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,6 +5659,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5556,6 +5685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,6 +5707,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1", features = ["v7"] }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-log = "2"
 log = "0.4"

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -33,6 +33,7 @@ pub fn run() {
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             ui_bridge::health,
             ui_bridge::list_focuses,

--- a/src-tauri/src/app/tray.rs
+++ b/src-tauri/src/app/tray.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use adhd_ranch_domain::{cap_state, Focus, Settings};
 use adhd_ranch_storage::FocusStore;
 use tauri::image::Image;
-use tauri::menu::{IsMenuItem, Menu, MenuItemBuilder, PredefinedMenuItem};
+use tauri::menu::{IsMenuItem, Menu, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::tray::{TrayIcon, TrayIconBuilder};
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 const QUIT_ID: &str = "tray-quit";
 const NO_FOCUSES_ID: &str = "tray-no-focuses";
+const DELETE_PREFIX: &str = "tray-delete-";
 
 pub fn setup<R: Runtime>(
     app: &AppHandle<R>,
@@ -29,8 +30,13 @@ pub fn setup<R: Runtime>(
         .menu(&menu)
         .show_menu_on_left_click(true)
         .on_menu_event(|app, event| {
-            if event.id().0 == QUIT_ID {
+            let id = event.id().0.as_str();
+            if id == QUIT_ID {
                 app.exit(0);
+            } else if let Some(focus_id) = id.strip_prefix(DELETE_PREFIX) {
+                let focus_id = focus_id.to_string();
+                let app_handle = app.clone();
+                std::thread::spawn(move || handle_delete(app_handle, focus_id));
             }
         });
 
@@ -86,11 +92,16 @@ fn build_menu<R: Runtime>(handle: &AppHandle<R>, focuses: &[Focus]) -> tauri::Re
             .build(handle)?;
         items.push(Box::new(item));
     } else {
-        for (i, focus) in focuses.iter().enumerate() {
-            let item = MenuItemBuilder::with_id(format!("tray-focus-{i}"), &focus.title)
-                .enabled(false)
-                .build(handle)?;
-            items.push(Box::new(item));
+        for focus in focuses.iter() {
+            let delete_item = MenuItemBuilder::with_id(
+                format!("{DELETE_PREFIX}{}", focus.id.0),
+                format!("Delete \"{}\"…", focus.title),
+            )
+            .build(handle)?;
+            let submenu = SubmenuBuilder::new(handle, &focus.title)
+                .item(&delete_item)
+                .build()?;
+            items.push(Box::new(submenu));
         }
     }
 
@@ -101,6 +112,34 @@ fn build_menu<R: Runtime>(handle: &AppHandle<R>, focuses: &[Focus]) -> tauri::Re
 
     let item_refs: Vec<&dyn IsMenuItem<R>> = items.iter().map(|b| b.as_ref()).collect();
     Menu::with_items(handle, &item_refs)
+}
+
+fn handle_delete<R: Runtime>(app: AppHandle<R>, focus_id: String) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+
+    let title = {
+        app.try_state::<crate::ui_bridge::CommandsState>()
+            .and_then(|state| state.0.list_focuses().ok())
+            .and_then(|focuses| focuses.into_iter().find(|f| f.id.0 == focus_id))
+            .map(|f| f.title)
+            .unwrap_or_else(|| focus_id.clone())
+    };
+
+    let confirmed = app
+        .dialog()
+        .message(format!("\"{}\" will be permanently removed.", title))
+        .title("Delete Focus?")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Delete".to_string(),
+            "Cancel".to_string(),
+        ))
+        .blocking_show();
+
+    if confirmed {
+        if let Some(state) = app.try_state::<crate::ui_bridge::CommandsState>() {
+            let _ = state.0.delete_focus(&focus_id);
+        }
+    }
 }
 
 fn red_icon() -> Image<'static> {

--- a/src-tauri/src/app/tray.rs
+++ b/src-tauri/src/app/tray.rs
@@ -137,7 +137,9 @@ fn handle_delete<R: Runtime>(app: AppHandle<R>, focus_id: String) {
 
     if confirmed {
         if let Some(state) = app.try_state::<crate::ui_bridge::CommandsState>() {
-            let _ = state.0.delete_focus(&focus_id);
+            if let Err(e) = state.0.delete_focus(&focus_id) {
+                log::error!("tray delete_focus({focus_id:?}): {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Each focus item in the tray NSMenu is now a `Submenu`; hovering the title shows an arrow
- Submenu contains a single "Delete \"{title}\"…" item
- Clicking shows a native macOS confirmation dialog (`tauri-plugin-dialog`)
- Confirming calls the existing `delete_focus` command → directory removed → file watcher fires → tray rebuilds + pig disappears within 1s
- Cancelling does nothing

## Implementation notes

- `tauri-plugin-dialog = "2"` added to Cargo.toml and registered in app setup
- `handle_delete` runs in a spawned thread (not the menu event dispatch thread) to allow blocking dialog API
- Focus title looked up from managed `CommandsState` before showing dialog (gives a human-readable confirmation message)
- Delete prefix `tray-delete-<focus_id_string>` is stored in the menu item ID

## Test plan

- [ ] `task check` green (CI)
- [ ] Open tray → each focus shows a submenu arrow
- [ ] Hover focus name → "Delete \"{title}\"…" appears
- [ ] Click delete item → native macOS dialog appears with correct title
- [ ] Cancel → nothing deleted, pig still present
- [ ] Confirm → focus directory removed, pig disappears within 1s, tray menu updates

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete individual focuses directly from the system tray via per-focus submenu entries, with a confirmation dialog to prevent accidental deletion.
* **User Experience**
  * Tray menu restructured to group per-focus actions into submenus for clearer, more accessible controls.
* **Chores**
  * Enabled native confirmation dialog support to power the new delete flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->