### PR TITLE
feat: 018 — larger pig hitbox

### DIFF
--- a/src/hooks/usePigMovement.test.ts
+++ b/src/hooks/usePigMovement.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { HITBOX_PADDING, PIG_SIZE, buildHitRects } from "./usePigMovement";
+import type { PigState } from "./usePigMovement";
+
+const makePig = (overrides?: Partial<PigState>): PigState => ({
+  id: "test",
+  name: "Test",
+  x: 100,
+  y: 200,
+  vx: 0,
+  vy: 0,
+  frameIndex: 0,
+  direction: "front",
+  lastFrameAt: 0,
+  nextTurnAt: 0,
+  ...overrides,
+});
+
+describe("HITBOX_PADDING", () => {
+  it("is exported and equals 16", () => {
+    expect(HITBOX_PADDING).toBe(16);
+  });
+});
+
+describe("buildHitRects", () => {
+  it("rect size is PIG_SIZE plus HITBOX_PADDING scaled by dpr", () => {
+    const dpr = 2;
+    const [rect] = buildHitRects([makePig()], dpr);
+    expect(rect?.size).toBe((PIG_SIZE + HITBOX_PADDING) * dpr);
+  });
+
+  it("rect x is centered — offset by half padding inward", () => {
+    const dpr = 1;
+    const pig = makePig({ x: 100 });
+    const [rect] = buildHitRects([pig], dpr);
+    expect(rect?.x).toBe((100 - HITBOX_PADDING / 2) * dpr);
+  });
+
+  it("rect y is centered — offset by half padding inward", () => {
+    const dpr = 1;
+    const pig = makePig({ y: 200 });
+    const [rect] = buildHitRects([pig], dpr);
+    expect(rect?.y).toBe((200 - HITBOX_PADDING / 2) * dpr);
+  });
+
+  it("dpr scales all dimensions", () => {
+    const dpr = 3;
+    const pig = makePig({ x: 50, y: 75 });
+    const [rect] = buildHitRects([pig], dpr);
+    expect(rect?.x).toBe((50 - HITBOX_PADDING / 2) * dpr);
+    expect(rect?.y).toBe((75 - HITBOX_PADDING / 2) * dpr);
+    expect(rect?.size).toBe((PIG_SIZE + HITBOX_PADDING) * dpr);
+  });
+
+  it("returns one rect per pig", () => {
+    const pigs = [makePig({ id: "a" }), makePig({ id: "b" }), makePig({ id: "c" })];
+    expect(buildHitRects(pigs, 1)).toHaveLength(3);
+  });
+});

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Focus } from "../types/focus";
 
 export const PIG_SIZE = 48;
+export const HITBOX_PADDING = 16;
 
 const PIG_SPEED = 35; // px/s
 const EDGE_MARGIN = 60; // px from screen edge
@@ -123,6 +124,17 @@ function tickPig(
   return { ...pig, x, y, vx, vy, frameIndex, direction, lastFrameAt, nextTurnAt };
 }
 
+export function buildHitRects(
+  pigs: PigState[],
+  dpr: number,
+): { x: number; y: number; size: number }[] {
+  return pigs.map((p) => ({
+    x: (p.x - HITBOX_PADDING / 2) * dpr,
+    y: (p.y - HITBOX_PADDING / 2) * dpr,
+    size: (PIG_SIZE + HITBOX_PADDING) * dpr,
+  }));
+}
+
 function syncRects(pigs: PigState[], detailOpen: boolean): void {
   const dpr = window.devicePixelRatio || 1;
   // When the detail card is open, send a full-viewport rect so the polling
@@ -130,7 +142,7 @@ function syncRects(pigs: PigState[], detailOpen: boolean): void {
   // and Escape go to the desktop instead of the overlay.
   const rects = detailOpen
     ? [{ x: 0, y: 0, size: Math.max(window.innerWidth, window.innerHeight) * dpr * 2 }]
-    : pigs.map((p) => ({ x: p.x * dpr, y: p.y * dpr, size: PIG_SIZE * dpr }));
+    : buildHitRects(pigs, dpr);
   invoke("update_pig_rects", { rects }).catch(() => {});
 }
 

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -124,10 +124,16 @@ function tickPig(
   return { ...pig, x, y, vx, vy, frameIndex, direction, lastFrameAt, nextTurnAt };
 }
 
+export interface PigHitRect {
+  x: number;
+  y: number;
+  size: number;
+}
+
 export function buildHitRects(
   pigs: PigState[],
   dpr: number,
-): { x: number; y: number; size: number }[] {
+): PigHitRect[] {
   return pigs.map((p) => ({
     x: (p.x - HITBOX_PADDING / 2) * dpr,
     y: (p.y - HITBOX_PADDING / 2) * dpr,


### PR DESCRIPTION
## Summary

- Adds `HITBOX_PADDING = 16` constant (exported)
- Extracts `buildHitRects(pigs, dpr)` as pure function — rect size is `PIG_SIZE + HITBOX_PADDING`, centred on sprite with `-(HITBOX_PADDING/2)` offset
- `syncRects` delegates to `buildHitRects`; no Rust changes needed

## Test plan

- [ ] 6 new unit tests covering padding size, x/y centering, dpr scaling, and multi-pig output
- [ ] `task check` green
- [ ] Clicking ~8px outside pig sprite still registers as pig click at runtime

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded and centered interaction areas around on-screen pigs so they are easier and more reliable to click or tap across display scales and device pixel ratios.

* **Tests**
  * Added automated tests validating hitbox padding, scaling, centering, and that one interaction rect is produced per pig to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->