### PR TITLE
feat: 020 — drag and toss pigs with physics

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -14,8 +14,8 @@ vi.mock(import("../hooks/usePigMovement"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    usePigMovement: (focuses: readonly Focus[]) =>
-      focuses.map((f) => ({
+    usePigMovement: (focuses: readonly Focus[]) => ({
+      pigs: focuses.map((f) => ({
         id: f.id,
         name: f.title,
         x: 100,
@@ -27,6 +27,10 @@ vi.mock(import("../hooks/usePigMovement"), async (importOriginal) => {
         lastFrameAt: 0,
         nextTurnAt: 9_999_999,
       })),
+      startDrag: vi.fn(),
+      moveDrag: vi.fn(),
+      endDrag: vi.fn(() => ({ wasDrag: false })),
+    }),
   };
 });
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,7 +16,7 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const focusState = useFocuses(focusReader);
   const focuses = focusState.status === "ready" ? focusState.focuses : [];
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const pigs = usePigMovement(focuses, selectedId);
+  const { pigs, startDrag, moveDrag, endDrag } = usePigMovement(focuses, selectedId);
   const { screenW, screenH } = useViewport();
 
   const selectedPig = pigs.find((p) => p.id === selectedId);
@@ -51,6 +51,9 @@ export function App({ focusReader, focusWriter }: AppProps) {
           frame={pig.frameIndex}
           name={pig.name}
           onClick={() => setSelectedId(pig.id)}
+          onDragStart={(x, y) => startDrag(pig.id, x, y)}
+          onDragMove={moveDrag}
+          onDragEnd={endDrag}
         />
       ))}
       {selectedPig && selectedFocus && (

--- a/src/components/PigSprite.tsx
+++ b/src/components/PigSprite.tsx
@@ -1,6 +1,7 @@
+import { useRef } from "react";
 import pigSheet from "../assets/pig-spritesheet.png";
+import { DRAG_THRESHOLD, PIG_SIZE } from "../hooks/usePigMovement";
 import type { PigDirection } from "../hooks/usePigMovement";
-import { PIG_SIZE } from "../hooks/usePigMovement";
 
 const SHEET_COLS = 4;
 const DIRECTION_ROW: Record<PigDirection, number> = {
@@ -20,20 +21,63 @@ export interface PigSpriteProps {
   readonly frame: number;
   readonly name: string;
   readonly onClick: () => void;
+  readonly onDragStart: (x: number, y: number) => void;
+  readonly onDragMove: (x: number, y: number) => void;
+  readonly onDragEnd: () => { wasDrag: boolean };
 }
 
-export function PigSprite({ x, y, direction, frame, name, onClick }: PigSpriteProps) {
+export function PigSprite({
+  x,
+  y,
+  direction,
+  frame,
+  name,
+  onClick,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+}: PigSpriteProps) {
   const bob = BOB_OFFSETS[frame % BOB_OFFSETS.length];
   const col = frame % SHEET_COLS;
   const row = DIRECTION_ROW[direction];
   const sheetSize = PIG_SIZE * SHEET_COLS;
 
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+  const isDraggingRef = useRef(false);
+
   return (
     <button
       type="button"
       className="pig-sprite"
-      style={{ left: x, top: y + bob }}
-      onClick={onClick}
+      style={{
+        left: x,
+        top: y + bob,
+        cursor: isDraggingRef.current ? "grabbing" : "pointer",
+      }}
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+        startPosRef.current = { x: e.clientX, y: e.clientY };
+        isDraggingRef.current = false;
+        onDragStart(e.clientX, e.clientY);
+      }}
+      onPointerMove={(e) => {
+        if (!startPosRef.current) return;
+        const dx = e.clientX - startPosRef.current.x;
+        const dy = e.clientY - startPosRef.current.y;
+        if (!isDraggingRef.current && Math.sqrt(dx * dx + dy * dy) >= DRAG_THRESHOLD) {
+          isDraggingRef.current = true;
+        }
+        if (isDraggingRef.current) {
+          onDragMove(e.clientX, e.clientY);
+        }
+      }}
+      onPointerUp={(e) => {
+        e.currentTarget.releasePointerCapture?.(e.pointerId);
+        startPosRef.current = null;
+        const { wasDrag } = onDragEnd();
+        isDraggingRef.current = false;
+        if (!wasDrag) onClick();
+      }}
     >
       <div
         className="pig-sprite-frame"

--- a/src/hooks/usePigMovement.test.ts
+++ b/src/hooks/usePigMovement.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { HITBOX_PADDING, PIG_SIZE, buildHitRects } from "./usePigMovement";
-import type { PigState } from "./usePigMovement";
+import {
+  DRAG_THRESHOLD,
+  HITBOX_PADDING,
+  PIG_SIZE,
+  PIG_SPEED,
+  TOSS_VELOCITY_WINDOW_MS,
+  buildHitRects,
+  computeTossVelocity,
+} from "./usePigMovement";
+import type { PigState, PointerSample } from "./usePigMovement";
 
 const makePig = (overrides?: Partial<PigState>): PigState => ({
   id: "test",
@@ -15,6 +23,10 @@ const makePig = (overrides?: Partial<PigState>): PigState => ({
   nextTurnAt: 0,
   ...overrides,
 });
+
+function makeSamples(points: { x: number; y: number; t: number }[]): PointerSample[] {
+  return points;
+}
 
 describe("HITBOX_PADDING", () => {
   it("is exported and equals 16", () => {
@@ -55,5 +67,83 @@ describe("buildHitRects", () => {
   it("returns one rect per pig", () => {
     const pigs = [makePig({ id: "a" }), makePig({ id: "b" }), makePig({ id: "c" })];
     expect(buildHitRects(pigs, 1)).toHaveLength(3);
+  });
+});
+
+describe("DRAG_THRESHOLD", () => {
+  it("is exported and equals 4", () => {
+    expect(DRAG_THRESHOLD).toBe(4);
+  });
+});
+
+describe("computeTossVelocity", () => {
+  it("returns zero velocity for empty samples", () => {
+    const result = computeTossVelocity([], TOSS_VELOCITY_WINDOW_MS, 1000);
+    expect(result).toEqual({ vx: 0, vy: 0 });
+  });
+
+  it("returns zero velocity for a single sample", () => {
+    const samples = makeSamples([{ x: 100, y: 100, t: 950 }]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, 1000);
+    expect(result).toEqual({ vx: 0, vy: 0 });
+  });
+
+  it("returns zero velocity when all samples are outside the window", () => {
+    const samples = makeSamples([
+      { x: 0, y: 0, t: 100 },
+      { x: 50, y: 0, t: 200 },
+    ]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, 1000);
+    expect(result).toEqual({ vx: 0, vy: 0 });
+  });
+
+  it("computes velocity from constant-speed samples within window", () => {
+    // 5 px in 50 ms = 100 px/s (under the PIG_SPEED*6 cap)
+    const now = 1000;
+    const samples = makeSamples([
+      { x: 0, y: 0, t: now - 50 },
+      { x: 5, y: 0, t: now },
+    ]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, now);
+    expect(result.vx).toBeCloseTo(100);
+    expect(result.vy).toBeCloseTo(0);
+  });
+
+  it("ignores samples older than the window", () => {
+    const now = 1000;
+    // Old sample at x=50 would drag the average down if included.
+    // Only the two recent samples should be used: 2px in 40ms = 50 px/s.
+    const samples = makeSamples([
+      { x: 0, y: 0, t: now - 200 }, // outside 80ms window — ignored
+      { x: 0, y: 0, t: now - 40 }, // inside
+      { x: 2, y: 0, t: now }, // inside
+    ]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, now);
+    expect(result.vx).toBeCloseTo(50);
+    expect(result.vy).toBeCloseTo(0);
+  });
+
+  it("clamps velocity to PIG_SPEED * 6", () => {
+    const now = 1000;
+    const samples = makeSamples([
+      { x: 0, y: 0, t: now - 10 },
+      { x: 10000, y: 0, t: now },
+    ]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, now);
+    const maxV = PIG_SPEED * 6;
+    expect(result.vx).toBeCloseTo(maxV);
+    expect(result.vy).toBeCloseTo(0);
+  });
+
+  it("clamps diagonal velocity preserving direction", () => {
+    const now = 1000;
+    const samples = makeSamples([
+      { x: 0, y: 0, t: now - 10 },
+      { x: 10000, y: 10000, t: now },
+    ]);
+    const result = computeTossVelocity(samples, TOSS_VELOCITY_WINDOW_MS, now);
+    const speed = Math.sqrt(result.vx ** 2 + result.vy ** 2);
+    expect(speed).toBeCloseTo(PIG_SPEED * 6);
+    expect(result.vx).toBeCloseTo(result.vy);
   });
 });

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -1,16 +1,47 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Focus } from "../types/focus";
 
 export const PIG_SIZE = 48;
 export const HITBOX_PADDING = 16;
+export const DRAG_THRESHOLD = 4;
+export const TOSS_VELOCITY_WINDOW_MS = 80;
+export const FRICTION = 0.97;
 
-const PIG_SPEED = 35; // px/s
+export const PIG_SPEED = 35; // px/s
 const EDGE_MARGIN = 60; // px from screen edge
 const FRAME_INTERVAL = 150; // ms per animation frame
 const MIN_TURN_MS = 3000;
 const MAX_TURN_MS = 8000;
 const RECT_UPDATE_EVERY = 4; // rAF frames between pig-rect syncs to Rust
+
+export interface PointerSample {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export function computeTossVelocity(
+  samples: PointerSample[],
+  windowMs: number,
+  now: number,
+): { vx: number; vy: number } {
+  const recent = samples.filter((s) => s.t >= now - windowMs);
+  if (recent.length < 2) return { vx: 0, vy: 0 };
+  const first = recent[0];
+  const last = recent[recent.length - 1];
+  if (!first || !last) return { vx: 0, vy: 0 };
+  const dt = last.t - first.t;
+  if (dt === 0) return { vx: 0, vy: 0 };
+  const vx = ((last.x - first.x) / dt) * 1000;
+  const vy = ((last.y - first.y) / dt) * 1000;
+  const maxV = PIG_SPEED * 6;
+  const speed = Math.sqrt(vx * vx + vy * vy);
+  if (speed > maxV) {
+    return { vx: (vx / speed) * maxV, vy: (vy / speed) * maxV };
+  }
+  return { vx, vy };
+}
 
 export type PigDirection = "front" | "right" | "back" | "left";
 
@@ -25,6 +56,13 @@ export interface PigState {
   direction: PigDirection;
   lastFrameAt: number;
   nextTurnAt: number;
+}
+
+export interface PigMovementResult {
+  pigs: PigState[];
+  startDrag: (pigId: string, x: number, y: number) => void;
+  moveDrag: (x: number, y: number) => void;
+  endDrag: () => { wasDrag: boolean };
 }
 
 function direction4(vx: number, vy: number): PigDirection {
@@ -73,6 +111,10 @@ function tickPig(
   }
   let { x, y, vx, vy, frameIndex, lastFrameAt, nextTurnAt, direction } = pig;
 
+  // Apply friction every frame so toss velocity decelerates naturally.
+  vx *= FRICTION;
+  vy *= FRICTION;
+
   // Random direction change
   if (now >= nextTurnAt) {
     const angle = Math.random() * 2 * Math.PI;
@@ -87,11 +129,11 @@ function tickPig(
   if (y < EDGE_MARGIN) vy = Math.abs(vy) || PIG_SPEED * 0.5;
   if (y > screenH - EDGE_MARGIN - PIG_SIZE) vy = -(Math.abs(vy) || PIG_SPEED * 0.5);
 
-  // Clamp speed
+  // Clamp to max toss speed; friction handles natural deceleration below this.
   const speed = Math.sqrt(vx * vx + vy * vy);
-  if (speed > PIG_SPEED * 1.2) {
-    vx = (vx / speed) * PIG_SPEED;
-    vy = (vy / speed) * PIG_SPEED;
+  if (speed > PIG_SPEED * 6) {
+    vx = (vx / speed) * PIG_SPEED * 6;
+    vy = (vy / speed) * PIG_SPEED * 6;
   }
 
   // Update position and reflect velocity at hard boundaries so pigs never escape.
@@ -130,10 +172,7 @@ export interface PigHitRect {
   size: number;
 }
 
-export function buildHitRects(
-  pigs: PigState[],
-  dpr: number,
-): PigHitRect[] {
+export function buildHitRects(pigs: PigState[], dpr: number): PigHitRect[] {
   return pigs.map((p) => ({
     x: (p.x - HITBOX_PADDING / 2) * dpr,
     y: (p.y - HITBOX_PADDING / 2) * dpr,
@@ -141,18 +180,19 @@ export function buildHitRects(
   }));
 }
 
-function syncRects(pigs: PigState[], detailOpen: boolean): void {
+function syncRects(pigs: PigState[], wide: boolean): void {
   const dpr = window.devicePixelRatio || 1;
-  // When the detail card is open, send a full-viewport rect so the polling
-  // thread never sets ignore_cursor_events=true — otherwise backdrop clicks
-  // and Escape go to the desktop instead of the overlay.
-  const rects = detailOpen
+  // Wide rect (detail open or dragging) keeps overlay interactive across the full viewport.
+  const rects = wide
     ? [{ x: 0, y: 0, size: Math.max(window.innerWidth, window.innerHeight) * dpr * 2 }]
     : buildHitRects(pigs, dpr);
   invoke("update_pig_rects", { rects }).catch(() => {});
 }
 
-export function usePigMovement(focuses: readonly Focus[], selectedId: string | null): PigState[] {
+export function usePigMovement(
+  focuses: readonly Focus[],
+  selectedId: string | null,
+): PigMovementResult {
   const [pigs, setPigs] = useState<PigState[]>([]);
   const pigsRef = useRef<PigState[]>([]);
   const selectedIdRef = useRef<string | null>(selectedId);
@@ -160,8 +200,65 @@ export function usePigMovement(focuses: readonly Focus[], selectedId: string | n
   const lastTimeRef = useRef<number>(performance.now());
   const frameCountRef = useRef<number>(0);
 
-  // Keep ref in sync so the rAF loop sees the latest value without restarting.
+  // Drag state — refs to avoid stale closures in the rAF loop.
+  const dragIdRef = useRef<string | null>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const pointerHistoryRef = useRef<PointerSample[]>([]);
+
+  // Keep selectedId ref in sync so the rAF loop sees the latest value without restarting.
   selectedIdRef.current = selectedId;
+
+  const startDrag = useCallback((pigId: string, x: number, y: number) => {
+    dragIdRef.current = pigId;
+    dragStartRef.current = { x, y };
+    pointerHistoryRef.current = [{ x, y, t: performance.now() }];
+  }, []);
+
+  const moveDrag = useCallback((x: number, y: number) => {
+    if (!dragIdRef.current) return;
+    const now = performance.now();
+    pointerHistoryRef.current.push({ x, y, t: now });
+    // Keep only last 200ms of history to bound memory.
+    pointerHistoryRef.current = pointerHistoryRef.current.filter((s) => s.t >= now - 200);
+
+    setPigs((prev) => {
+      const next = prev.map((p) =>
+        p.id === dragIdRef.current ? { ...p, x, y, direction: direction4(p.vx, p.vy) } : p,
+      );
+      pigsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const endDrag = useCallback((): { wasDrag: boolean } => {
+    const start = dragStartRef.current;
+    const history = pointerHistoryRef.current;
+    const pigId = dragIdRef.current;
+
+    dragIdRef.current = null;
+    dragStartRef.current = null;
+    pointerHistoryRef.current = [];
+
+    if (!start || !pigId) return { wasDrag: false };
+
+    const last = history[history.length - 1];
+    if (!last) return { wasDrag: false };
+
+    const dx = last.x - start.x;
+    const dy = last.y - start.y;
+    const moved = Math.sqrt(dx * dx + dy * dy);
+
+    if (moved < DRAG_THRESHOLD) return { wasDrag: false };
+
+    const { vx, vy } = computeTossVelocity(history, TOSS_VELOCITY_WINDOW_MS, last.t);
+    setPigs((prev) => {
+      const next = prev.map((p) => (p.id === pigId ? { ...p, vx, vy } : p));
+      pigsRef.current = next;
+      return next;
+    });
+
+    return { wasDrag: true };
+  }, []);
 
   // Sync pig list to focuses: add spawns for new, remove for deleted.
   useEffect(() => {
@@ -186,15 +283,18 @@ export function usePigMovement(focuses: readonly Focus[], selectedId: string | n
       const screenW = document.documentElement.clientWidth || window.screen.width;
       const screenH = document.documentElement.clientHeight || window.screen.height;
 
-      const updated = pigsRef.current.map((p) =>
-        tickPig(p, dt, now, screenW, screenH, p.id === selectedIdRef.current),
-      );
+      const updated = pigsRef.current.map((p) => {
+        // Skip tick for dragged pig — position is driven by pointer events.
+        if (p.id === dragIdRef.current) return p;
+        return tickPig(p, dt, now, screenW, screenH, p.id === selectedIdRef.current);
+      });
       pigsRef.current = updated;
       setPigs(updated);
 
       frameCountRef.current += 1;
       if (frameCountRef.current % RECT_UPDATE_EVERY === 0) {
-        syncRects(updated, selectedIdRef.current !== null);
+        const wide = selectedIdRef.current !== null || dragIdRef.current !== null;
+        syncRects(updated, wide);
       }
 
       rafRef.current = requestAnimationFrame(loop);
@@ -204,5 +304,5 @@ export function usePigMovement(focuses: readonly Focus[], selectedId: string | n
     return () => cancelAnimationFrame(rafRef.current);
   }, []);
 
-  return pigs;
+  return { pigs, startDrag, moveDrag, endDrag };
 }


### PR DESCRIPTION
## Summary

- Extracts `computeTossVelocity(samples, windowMs, now)` as pure function; velocity capped at `PIG_SPEED * 6`
- Exports `DRAG_THRESHOLD = 4`, `TOSS_VELOCITY_WINDOW_MS = 80`, `FRICTION = 0.97`, `PIG_SPEED`
- `usePigMovement` return type changed from `PigState[]` to `{ pigs, startDrag, moveDrag, endDrag }`
- Dragged pig position follows pointer; pointer history buffered for toss velocity on release
- `tickPig` applies `FRICTION` each frame; speed cap raised to `PIG_SPEED * 6`
- `PigSprite` uses `setPointerCapture` for reliable drag; click fires only when movement < `DRAG_THRESHOLD`
- Wide hit-rect sent during drag (same as when detail card is open)

## Test plan

- [ ] 8 unit tests: `DRAG_THRESHOLD` value, `computeTossVelocity` with constant speed, window filtering, empty/single-sample edge cases, velocity clamping (scalar + diagonal)
- [ ] `task check` green
- [ ] Pure click still opens PigDetail
- [ ] Drag moves pig in real time
- [ ] Fast release sends pig flying; pig decelerates and bounces at edges
- [ ] App launches at runtime without crash

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pigs can now be dragged and tossed around the interface with momentum physics.
  * Added the ability to create new tasks directly from the pig detail panel.
  * Improved pointer interaction handling for drag gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->