### PR TITLE
[028-focus-timer]: Focus timer: domain types + full-stack creation

### DIFF
--- a/crates/commands/src/caps.rs
+++ b/crates/commands/src/caps.rs
@@ -141,6 +141,7 @@ mod tests {
             _new_focus: &NewFocus,
             _id: &str,
             _created_at: &str,
+            _timer: Option<adhd_ranch_domain::FocusTimer>,
         ) -> Result<String, FocusStoreError> {
             unimplemented!()
         }
@@ -167,6 +168,7 @@ mod tests {
                     text: format!("t{i}"),
                 })
                 .collect(),
+            timer: None,
         }
     }
 

--- a/crates/commands/src/focus.rs
+++ b/crates/commands/src/focus.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use adhd_ranch_domain::{Caps, Focus, NewFocus};
+use adhd_ranch_domain::{Caps, Focus, FocusTimer, NewFocus, TimerPreset, TimerStatus};
 use adhd_ranch_storage::FocusStore;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +12,8 @@ pub struct CreateFocusInput {
     pub title: String,
     #[serde(default)]
     pub description: String,
+    #[serde(default)]
+    pub timer_preset: Option<TimerPreset>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -24,10 +26,11 @@ pub(crate) fn create_focus_in_store(
     clock: &Clock,
     id_gen: &IdGen,
     new_focus: &NewFocus,
+    timer: Option<FocusTimer>,
 ) -> Result<String, CommandError> {
     let id = id_gen();
     let created_at = clock();
-    Ok(store.create_focus(new_focus, &id, &created_at)?)
+    Ok(store.create_focus(new_focus, &id, &created_at, timer)?)
 }
 
 impl Commands {
@@ -39,11 +42,18 @@ impl Commands {
         if input.title.trim().is_empty() {
             return Err(CommandError::BadRequest("title must not be empty".into()));
         }
+        let timer = input.timer_preset.as_ref().map(|preset| FocusTimer {
+            duration_secs: preset.duration_secs(),
+            started_at: (self.clock_secs)(),
+            status: TimerStatus::Running,
+        });
         let new_focus = NewFocus {
             title: input.title,
             description: input.description,
+            timer_preset: input.timer_preset,
         };
-        let slug = create_focus_in_store(&self.store, &self.clock, &self.id_gen, &new_focus)?;
+        let slug =
+            create_focus_in_store(&self.store, &self.clock, &self.id_gen, &new_focus, timer)?;
         Ok(CreatedFocus { id: slug })
     }
 
@@ -67,5 +77,70 @@ impl Commands {
 
     pub fn caps(&self) -> Caps {
         self.settings.caps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use adhd_ranch_domain::{Settings, TimerStatus};
+    use adhd_ranch_storage::{JsonlDecisionLog, JsonlProposalQueue, MarkdownFocusStore};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn build_commands(clock_secs_val: i64) -> (Commands, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let focuses_root = dir.path().join("focuses");
+        std::fs::create_dir_all(&focuses_root).unwrap();
+        let store: Arc<dyn adhd_ranch_storage::FocusStore> =
+            Arc::new(MarkdownFocusStore::new(focuses_root));
+        let queue: Arc<dyn adhd_ranch_storage::ProposalQueue> =
+            Arc::new(JsonlProposalQueue::new(dir.path().join("proposals.jsonl")));
+        let decisions: Arc<dyn adhd_ranch_storage::DecisionLog> =
+            Arc::new(JsonlDecisionLog::new(dir.path().join("decisions.jsonl")));
+        let commands = Commands::new(
+            store,
+            queue,
+            decisions,
+            Arc::new(|| "2026-01-01T00:00:00Z".to_string()),
+            Arc::new(move || clock_secs_val),
+            Arc::new(|| "test-id".to_string()),
+            Settings::default(),
+        );
+        (commands, dir)
+    }
+
+    #[test]
+    fn create_focus_without_preset_stores_no_timer() {
+        let (commands, _dir) = build_commands(1_000_000);
+        commands
+            .create_focus(CreateFocusInput {
+                title: "No timer focus".into(),
+                description: String::new(),
+                timer_preset: None,
+            })
+            .unwrap();
+        let focuses = commands.list_focuses().unwrap();
+        assert_eq!(focuses.len(), 1);
+        assert!(focuses[0].timer.is_none());
+    }
+
+    #[test]
+    fn create_focus_with_preset_stores_timer_with_correct_duration() {
+        let started_at = 1_700_000_000_i64;
+        let (commands, _dir) = build_commands(started_at);
+        commands
+            .create_focus(CreateFocusInput {
+                title: "Timer focus".into(),
+                description: String::new(),
+                timer_preset: Some(TimerPreset::Eight),
+            })
+            .unwrap();
+        let focuses = commands.list_focuses().unwrap();
+        assert_eq!(focuses.len(), 1);
+        let timer = focuses[0].timer.as_ref().expect("timer should be Some");
+        assert_eq!(timer.duration_secs, 480);
+        assert_eq!(timer.started_at, started_at);
+        assert_eq!(timer.status, TimerStatus::Running);
     }
 }

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -16,6 +16,7 @@ pub use lifecycle::ProposalLifecycle;
 pub use proposal::{CreateProposalInput, CreatedProposal, DecisionOutcome, ProposalEdit};
 
 pub type Clock = Arc<dyn Fn() -> String + Send + Sync>;
+pub type ClockSecs = Arc<dyn Fn() -> i64 + Send + Sync>;
 pub type IdGen = Arc<dyn Fn() -> String + Send + Sync>;
 
 pub struct Commands {
@@ -23,6 +24,7 @@ pub struct Commands {
     pub(crate) queue: Arc<dyn ProposalQueue>,
     pub(crate) lifecycle: Arc<ProposalLifecycle>,
     pub(crate) clock: Clock,
+    pub(crate) clock_secs: ClockSecs,
     pub(crate) id_gen: IdGen,
     pub(crate) settings: Settings,
 }
@@ -33,6 +35,7 @@ impl Commands {
         queue: Arc<dyn ProposalQueue>,
         decisions: Arc<dyn DecisionLog>,
         clock: Clock,
+        clock_secs: ClockSecs,
         id_gen: IdGen,
         settings: Settings,
     ) -> Self {
@@ -48,6 +51,7 @@ impl Commands {
             queue,
             lifecycle,
             clock,
+            clock_secs,
             id_gen,
             settings,
         }

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -44,6 +44,7 @@ impl Commands {
             queue.clone(),
             decisions,
             clock.clone(),
+            clock_secs.clone(),
             id_gen.clone(),
         ));
         Self {

--- a/crates/commands/src/lifecycle.rs
+++ b/crates/commands/src/lifecycle.rs
@@ -1,18 +1,21 @@
 use std::sync::Arc;
 
-use adhd_ranch_domain::{Decision, DecisionKind, Proposal, ProposalId, ProposalKind};
+use adhd_ranch_domain::{
+    Decision, DecisionKind, FocusTimer, Proposal, ProposalId, ProposalKind, TimerStatus,
+};
 use adhd_ranch_storage::{DecisionLog, FocusStore, ProposalQueue};
 
 use crate::error::CommandError;
 use crate::focus::create_focus_in_store;
 use crate::proposal::{DecisionOutcome, ProposalEdit};
-use crate::{Clock, IdGen};
+use crate::{Clock, ClockSecs, IdGen};
 
 pub struct ProposalLifecycle {
     store: Arc<dyn FocusStore>,
     queue: Arc<dyn ProposalQueue>,
     decisions: Arc<dyn DecisionLog>,
     clock: Clock,
+    clock_secs: ClockSecs,
     id_gen: IdGen,
 }
 
@@ -22,6 +25,7 @@ impl ProposalLifecycle {
         queue: Arc<dyn ProposalQueue>,
         decisions: Arc<dyn DecisionLog>,
         clock: Clock,
+        clock_secs: ClockSecs,
         id_gen: IdGen,
     ) -> Self {
         Self {
@@ -29,6 +33,7 @@ impl ProposalLifecycle {
             queue,
             decisions,
             clock,
+            clock_secs,
             id_gen,
         }
     }
@@ -66,8 +71,18 @@ impl ProposalLifecycle {
                 Ok(Some(target_focus_id.clone()))
             }
             ProposalKind::NewFocus { new_focus } => {
-                let slug =
-                    create_focus_in_store(&self.store, &self.clock, &self.id_gen, new_focus, None)?;
+                let timer = new_focus.timer_preset.as_ref().map(|preset| FocusTimer {
+                    duration_secs: preset.duration_secs(),
+                    started_at: (self.clock_secs)(),
+                    status: TimerStatus::Running,
+                });
+                let slug = create_focus_in_store(
+                    &self.store,
+                    &self.clock,
+                    &self.id_gen,
+                    new_focus,
+                    timer,
+                )?;
                 Ok(Some(slug))
             }
             ProposalKind::Discard => Ok(None),
@@ -161,9 +176,11 @@ mod tests {
         let decisions: Arc<dyn DecisionLog> =
             Arc::new(JsonlDecisionLog::new(decisions_path.clone()));
         let clock: Clock = Arc::new(|| "2026-04-30T12:00:00Z".to_string());
+        let clock_secs: crate::ClockSecs = Arc::new(|| 1_700_000_000);
         let id_gen: IdGen = Arc::new(|| "id-fixed".to_string());
 
-        let lifecycle = ProposalLifecycle::new(store, queue.clone(), decisions, clock, id_gen);
+        let lifecycle =
+            ProposalLifecycle::new(store, queue.clone(), decisions, clock, clock_secs, id_gen);
         Harness {
             _dir: dir,
             focuses_root,

--- a/crates/commands/src/lifecycle.rs
+++ b/crates/commands/src/lifecycle.rs
@@ -67,7 +67,7 @@ impl ProposalLifecycle {
             }
             ProposalKind::NewFocus { new_focus } => {
                 let slug =
-                    create_focus_in_store(&self.store, &self.clock, &self.id_gen, new_focus)?;
+                    create_focus_in_store(&self.store, &self.clock, &self.id_gen, new_focus, None)?;
                 Ok(Some(slug))
             }
             ProposalKind::Discard => Ok(None),
@@ -229,6 +229,7 @@ mod tests {
                     new_focus: NewFocus {
                         title: "Customer X bug".into(),
                         description: "ship".into(),
+                        timer_preset: None,
                     },
                 },
             ))

--- a/crates/commands/src/proposal.rs
+++ b/crates/commands/src/proposal.rs
@@ -56,6 +56,7 @@ impl Commands {
                 new_focus: input.new_focus.clone().unwrap_or(NewFocus {
                     title: String::new(),
                     description: String::new(),
+                    timer_preset: None,
                 }),
             },
             "discard" => ProposalKind::Discard,

--- a/crates/domain/src/caps.rs
+++ b/crates/domain/src/caps.rs
@@ -46,6 +46,7 @@ mod tests {
                     text: format!("t{i}"),
                 })
                 .collect(),
+            timer: None,
         }
     }
 

--- a/crates/domain/src/focus.rs
+++ b/crates/domain/src/focus.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::timer::FocusTimer;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FocusId(pub String);
 
@@ -16,6 +18,8 @@ pub struct Focus {
     pub description: String,
     pub created_at: String,
     pub tasks: Vec<Task>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timer: Option<FocusTimer>,
 }
 
 #[cfg(test)]
@@ -33,6 +37,7 @@ mod tests {
                 id: "abc:0".into(),
                 text: "step one".into(),
             }],
+            timer: None,
         };
         let json = serde_json::to_string(&f).expect("serialize");
         let back: Focus = serde_json::from_str(&json).expect("deserialize");

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pig_rect;
 pub mod proposal;
 pub mod settings;
 pub mod slug;
+pub mod timer;
 
 pub use cap_monitor::{CapTransition, OverCapMonitor};
 pub use caps::{cap_state, CapState};
@@ -17,3 +18,4 @@ pub use pig_rect::{PigRect, RectUpdater};
 pub use proposal::{NewFocus, Proposal, ProposalId, ProposalKind, ProposalValidationError};
 pub use settings::{Alerts, Caps, DisplayConfig, Settings, Widget};
 pub use slug::slugify;
+pub use timer::{growth_factor, timer_remaining_secs, FocusTimer, TimerPreset, TimerStatus};

--- a/crates/domain/src/parse.rs
+++ b/crates/domain/src/parse.rs
@@ -38,6 +38,7 @@ pub fn parse_focus_md(input: &str) -> Result<Focus, ParseError> {
         description,
         created_at,
         tasks,
+        timer: None,
     })
 }
 

--- a/crates/domain/src/proposal.rs
+++ b/crates/domain/src/proposal.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::timer::TimerPreset;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProposalId(pub String);
 
@@ -7,6 +9,8 @@ pub struct ProposalId(pub String);
 pub struct NewFocus {
     pub title: String,
     pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timer_preset: Option<TimerPreset>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -139,6 +143,7 @@ mod tests {
             new_focus: NewFocus {
                 title: "".into(),
                 description: "x".into(),
+                timer_preset: None,
             },
         });
         assert_eq!(
@@ -181,6 +186,7 @@ mod tests {
             new_focus: NewFocus {
                 title: "T".into(),
                 description: "D".into(),
+                timer_preset: None,
             },
         });
         let json = serde_json::to_string(&original).unwrap();

--- a/crates/domain/src/timer.rs
+++ b/crates/domain/src/timer.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimerStatus {
+    Running,
+    Expired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimerPreset {
+    Two,
+    Four,
+    Eight,
+    Sixteen,
+    ThirtyTwo,
+    Custom(u64), // minutes
+}
+
+impl TimerPreset {
+    pub fn duration_secs(&self) -> u64 {
+        match self {
+            Self::Two => 120,
+            Self::Four => 240,
+            Self::Eight => 480,
+            Self::Sixteen => 960,
+            Self::ThirtyTwo => 1920,
+            Self::Custom(mins) => mins * 60,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FocusTimer {
+    pub duration_secs: u64,
+    pub started_at: i64,
+    pub status: TimerStatus,
+}
+
+/// Returns seconds remaining, or None if the timer has expired.
+pub fn timer_remaining_secs(timer: &FocusTimer, now_secs: i64) -> Option<u64> {
+    let elapsed = (now_secs - timer.started_at).max(0) as u64;
+    if elapsed >= timer.duration_secs {
+        None
+    } else {
+        Some(timer.duration_secs - elapsed)
+    }
+}
+
+/// Returns a growth multiplier in 1.0..=3.0 based on elapsed time vs total duration.
+/// 1.0 at t=0, 3.0 at t>=duration_secs.
+pub fn growth_factor(elapsed_secs: u64, duration_secs: u64) -> f32 {
+    if duration_secs == 0 {
+        return 3.0;
+    }
+    let progress = (elapsed_secs as f32 / duration_secs as f32).clamp(0.0, 1.0);
+    1.0 + progress * 2.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn running_timer(duration_secs: u64, started_at: i64) -> FocusTimer {
+        FocusTimer {
+            duration_secs,
+            started_at,
+            status: TimerStatus::Running,
+        }
+    }
+
+    #[test]
+    fn remaining_at_start_equals_duration() {
+        let t = running_timer(120, 1000);
+        assert_eq!(timer_remaining_secs(&t, 1000), Some(120));
+    }
+
+    #[test]
+    fn remaining_mid_timer_is_correct() {
+        let t = running_timer(120, 1000);
+        assert_eq!(timer_remaining_secs(&t, 1060), Some(60));
+    }
+
+    #[test]
+    fn remaining_at_expiry_is_none() {
+        let t = running_timer(120, 1000);
+        assert_eq!(timer_remaining_secs(&t, 1120), None);
+    }
+
+    #[test]
+    fn remaining_past_expiry_is_none() {
+        let t = running_timer(120, 1000);
+        assert_eq!(timer_remaining_secs(&t, 2000), None);
+    }
+
+    #[test]
+    fn growth_factor_at_start_is_one() {
+        assert!((growth_factor(0, 120) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn growth_factor_at_half_duration_is_two() {
+        assert!((growth_factor(60, 120) - 2.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn growth_factor_at_full_duration_is_three() {
+        assert!((growth_factor(120, 120) - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn growth_factor_past_duration_clamped_to_three() {
+        assert!((growth_factor(9999, 120) - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn preset_duration_secs_correct() {
+        assert_eq!(TimerPreset::Two.duration_secs(), 120);
+        assert_eq!(TimerPreset::Four.duration_secs(), 240);
+        assert_eq!(TimerPreset::Eight.duration_secs(), 480);
+        assert_eq!(TimerPreset::Sixteen.duration_secs(), 960);
+        assert_eq!(TimerPreset::ThirtyTwo.duration_secs(), 1920);
+        assert_eq!(TimerPreset::Custom(10).duration_secs(), 600);
+    }
+
+    #[test]
+    fn focus_timer_round_trips_via_serde() {
+        let t = FocusTimer {
+            duration_secs: 480,
+            started_at: 1_700_000_000,
+            status: TimerStatus::Running,
+        };
+        let json = serde_json::to_string(&t).expect("serialize");
+        let back: FocusTimer = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(t, back);
+    }
+}

--- a/crates/domain/src/timer.rs
+++ b/crates/domain/src/timer.rs
@@ -24,7 +24,7 @@ impl TimerPreset {
             Self::Eight => 480,
             Self::Sixteen => 960,
             Self::ThirtyTwo => 1920,
-            Self::Custom(mins) => mins * 60,
+            Self::Custom(mins) => mins.saturating_mul(60),
         }
     }
 }
@@ -37,7 +37,11 @@ pub struct FocusTimer {
 }
 
 /// Returns seconds remaining, or None if the timer has expired.
+/// Short-circuits on explicit Expired status regardless of clock.
 pub fn timer_remaining_secs(timer: &FocusTimer, now_secs: i64) -> Option<u64> {
+    if matches!(timer.status, TimerStatus::Expired) {
+        return None;
+    }
     let elapsed = (now_secs - timer.started_at).max(0) as u64;
     if elapsed >= timer.duration_secs {
         None
@@ -90,6 +94,22 @@ mod tests {
     fn remaining_past_expiry_is_none() {
         let t = running_timer(120, 1000);
         assert_eq!(timer_remaining_secs(&t, 2000), None);
+    }
+
+    #[test]
+    fn remaining_returns_none_when_status_expired_regardless_of_clock() {
+        let t = FocusTimer {
+            duration_secs: 120,
+            started_at: 1000,
+            status: TimerStatus::Expired,
+        };
+        // Clock says there's still 60s left, but status is Expired — must return None.
+        assert_eq!(timer_remaining_secs(&t, 1060), None);
+    }
+
+    #[test]
+    fn custom_preset_saturates_on_overflow() {
+        assert_eq!(TimerPreset::Custom(u64::MAX).duration_secs(), u64::MAX);
     }
 
     #[test]

--- a/crates/http-api/src/router/mod.rs
+++ b/crates/http-api/src/router/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use adhd_ranch_commands::{Clock, CommandError, Commands, IdGen};
+use adhd_ranch_commands::{Clock, ClockSecs, CommandError, Commands, IdGen};
 use adhd_ranch_domain::Settings;
 use adhd_ranch_storage::{DecisionLog, FocusStore, ProposalQueue};
 use axum::http::StatusCode;
@@ -47,13 +47,14 @@ pub fn router_with(
     deps: ServerDeps,
 ) -> Router {
     let clock: Clock = deps.clock.unwrap_or_else(|| Arc::new(now_rfc3339));
+    let clock_secs: ClockSecs = Arc::new(now_unix_secs);
     let id_gen: IdGen = deps
         .id_gen
         .unwrap_or_else(|| Arc::new(|| uuid::Uuid::now_v7().to_string()));
     let settings = deps.settings.unwrap_or_default();
 
     let commands = Arc::new(Commands::new(
-        store, queue, decisions, clock, id_gen, settings,
+        store, queue, decisions, clock, clock_secs, id_gen, settings,
     ));
     let state = AppState { commands };
 
@@ -68,6 +69,10 @@ fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| String::new())
+}
+
+fn now_unix_secs() -> i64 {
+    time::OffsetDateTime::now_utc().unix_timestamp()
 }
 
 #[derive(Debug)]

--- a/crates/http-api/src/router/mod.rs
+++ b/crates/http-api/src/router/mod.rs
@@ -23,6 +23,7 @@ pub struct FocusCatalogEntry {
 #[derive(Clone, Default)]
 pub struct ServerDeps {
     pub clock: Option<Clock>,
+    pub clock_secs: Option<ClockSecs>,
     pub id_gen: Option<IdGen>,
     pub settings: Option<Settings>,
 }
@@ -47,7 +48,7 @@ pub fn router_with(
     deps: ServerDeps,
 ) -> Router {
     let clock: Clock = deps.clock.unwrap_or_else(|| Arc::new(now_rfc3339));
-    let clock_secs: ClockSecs = Arc::new(now_unix_secs);
+    let clock_secs: ClockSecs = deps.clock_secs.unwrap_or_else(|| Arc::new(now_unix_secs));
     let id_gen: IdGen = deps
         .id_gen
         .unwrap_or_else(|| Arc::new(|| uuid::Uuid::now_v7().to_string()));

--- a/crates/http-api/src/router/tests.rs
+++ b/crates/http-api/src/router/tests.rs
@@ -58,6 +58,7 @@ fn make_app(dir: &std::path::Path) -> Harness {
         decisions,
         ServerDeps {
             clock: Some(fixed_clock("2026-04-30T12:00:00Z")),
+            clock_secs: Some(std::sync::Arc::new(|| 1_700_000_000)),
             id_gen: Some(fixed_id("p-test")),
             settings: None,
         },

--- a/crates/storage/src/focus_store.rs
+++ b/crates/storage/src/focus_store.rs
@@ -110,9 +110,11 @@ impl FocusStore for MarkdownFocusStore {
             focus.id = adhd_ranch_domain::FocusId(entry.file_name().to_string_lossy().into_owned());
             let timer_path = entry.path().join("timer.json");
             if timer_path.is_file() {
-                if let Ok(raw) = fs::read_to_string(&timer_path) {
-                    focus.timer = serde_json::from_str(&raw).ok();
-                }
+                let raw = fs::read_to_string(&timer_path)?;
+                focus.timer = Some(
+                    serde_json::from_str(&raw)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                );
             }
             out.push(focus);
         }
@@ -148,7 +150,10 @@ impl FocusStore for MarkdownFocusStore {
 
         if let Some(t) = timer {
             let json = serde_json::to_vec(&t).map_err(io::Error::other)?;
-            atomic_write(&dir.join("timer.json"), &json)?;
+            if let Err(err) = atomic_write(&dir.join("timer.json"), &json) {
+                let _ = fs::remove_dir_all(&dir);
+                return Err(err.into());
+            }
         }
 
         Ok(slug)

--- a/crates/storage/src/focus_store.rs
+++ b/crates/storage/src/focus_store.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use adhd_ranch_domain::{parse_focus_md, slugify, Focus, NewFocus, ParseError};
+use adhd_ranch_domain::{parse_focus_md, slugify, Focus, FocusTimer, NewFocus, ParseError};
 
 use crate::atomic::atomic_write;
 
@@ -46,6 +46,7 @@ pub trait FocusStore: Send + Sync {
         new_focus: &NewFocus,
         id: &str,
         created_at: &str,
+        timer: Option<FocusTimer>,
     ) -> Result<String, FocusStoreError>;
     fn delete_focus(&self, focus_id: &str) -> Result<(), FocusStoreError>;
     fn append_task(&self, focus_id: &str, text: &str) -> Result<(), FocusStoreError>;
@@ -107,6 +108,12 @@ impl FocusStore for MarkdownFocusStore {
             // frontmatter uuid field. All store ops (delete, append_task, etc.)
             // join focus_id to the root dir, so the ID must be the slug.
             focus.id = adhd_ranch_domain::FocusId(entry.file_name().to_string_lossy().into_owned());
+            let timer_path = entry.path().join("timer.json");
+            if timer_path.is_file() {
+                if let Ok(raw) = fs::read_to_string(&timer_path) {
+                    focus.timer = serde_json::from_str(&raw).ok();
+                }
+            }
             out.push(focus);
         }
 
@@ -123,6 +130,7 @@ impl FocusStore for MarkdownFocusStore {
         new_focus: &NewFocus,
         id: &str,
         created_at: &str,
+        timer: Option<FocusTimer>,
     ) -> Result<String, FocusStoreError> {
         let slug = slugify(&new_focus.title);
         let dir = self.root.join(&slug);
@@ -137,6 +145,12 @@ impl FocusStore for MarkdownFocusStore {
             description = new_focus.description,
         );
         atomic_write(&dir.join("focus.md"), body.as_bytes())?;
+
+        if let Some(t) = timer {
+            let json = serde_json::to_vec(&t).map_err(io::Error::other)?;
+            atomic_write(&dir.join("timer.json"), &json)?;
+        }
+
         Ok(slug)
     }
 
@@ -344,9 +358,11 @@ mod tests {
                 &NewFocus {
                     title: "Customer X bug".into(),
                     description: "ship it".into(),
+                    timer_preset: None,
                 },
                 "id-1",
                 "2026-04-30T12:00:00Z",
+                None,
             )
             .unwrap();
         assert_eq!(slug, "customer-x-bug");
@@ -366,9 +382,11 @@ mod tests {
                 &NewFocus {
                     title: "Customer X bug".into(),
                     description: "".into(),
+                    timer_preset: None,
                 },
                 "id-2",
                 "2026-04-30T12:00:00Z",
+                None,
             )
             .unwrap_err();
         assert!(matches!(err, FocusStoreError::AlreadyExists(slug) if slug == "customer-x-bug"));

--- a/crates/storage/src/proposals.rs
+++ b/crates/storage/src/proposals.rs
@@ -103,6 +103,7 @@ mod tests {
                     new_focus: NewFocus {
                         title: format!("T{i}"),
                         description: String::new(),
+                        timer_preset: None,
                     },
                 },
             );

--- a/issues/028-focus-timer-domain-and-creation.md
+++ b/issues/028-focus-timer-domain-and-creation.md
@@ -1,0 +1,65 @@
+# 028 — Focus timer: domain types + full-stack creation
+
+## Parent PRD
+
+PRD.md §FR3 (pig UI) + §FR7 (configuration)
+
+## What to build
+
+Add timer support to focuses end-to-end: domain types, persistence, and the creation UI.
+
+### Domain (`crates/domain/src/timer.rs`)
+
+```rust
+pub enum TimerStatus { Running, Expired }
+
+pub enum TimerPreset { Two, Four, Eight, Sixteen, ThirtyTwo, Custom(u64) }
+// duration_secs(): 120, 240, 480, 960, 1920, custom value
+
+pub struct FocusTimer {
+    pub duration_secs: u64,
+    pub started_at: i64,   // unix timestamp (secs)
+    pub status: TimerStatus,
+}
+
+pub fn timer_remaining_secs(timer: &FocusTimer, now_secs: i64) -> Option<u64>
+// Returns None when expired, Some(remaining) while running.
+
+pub fn pig_scale(elapsed_secs: u64, duration_secs: u64) -> f32
+// Returns 1.0..=3.0 clamped. Linear interpolation over full timer window.
+```
+
+- `Focus` gains `timer: Option<FocusTimer>`
+- `NewFocus` gains `timer_preset: Option<TimerPreset>`
+- Both serialise/deserialise correctly through `settings.yaml` and the HTTP API
+
+### Backend
+
+- `create_focus` command/handler accepts `timer_preset: Option<TimerPreset>`
+- When present: constructs `FocusTimer { started_at: now, duration_secs, status: Running }`
+- Timer persisted alongside focus
+
+### Frontend
+
+- `NewFocusForm` gains a timer dropdown: **None / 2m / 4m / 8m / 16m / 32m / Custom**
+- Custom shows a number input (minutes)
+- Selected preset sent with focus creation request
+
+## Completion promise
+
+User can create a focus with a timer preset; the timer is stored and readable via the API with correct remaining time.
+
+## Acceptance criteria
+
+- [ ] `TimerPreset`, `FocusTimer`, `TimerStatus` defined in `crates/domain/src/timer.rs`
+- [ ] `timer_remaining_secs` returns correct value at t=0, mid-duration, and past expiry
+- [ ] `pig_scale` returns 1.0 at t=0, ~2.0 at half duration, 3.0 at/past full duration
+- [ ] Unit tests cover both pure functions including boundary values
+- [ ] `Focus` and `NewFocus` carry optional timer fields; round-trips through serde
+- [ ] `NewFocusForm` renders timer dropdown; Custom shows number input
+- [ ] Creating a focus with a preset stores a `FocusTimer` with correct `started_at` and `duration_secs`
+- [ ] `task check` green
+
+## Blocked by
+
+None — can start immediately.

--- a/issues/028-focus-timer-domain-and-creation.md
+++ b/issues/028-focus-timer-domain-and-creation.md
@@ -25,7 +25,7 @@ pub struct FocusTimer {
 pub fn timer_remaining_secs(timer: &FocusTimer, now_secs: i64) -> Option<u64>
 // Returns None when expired, Some(remaining) while running.
 
-pub fn pig_scale(elapsed_secs: u64, duration_secs: u64) -> f32
+pub fn growth_factor(elapsed_secs: u64, duration_secs: u64) -> f32
 // Returns 1.0..=3.0 clamped. Linear interpolation over full timer window.
 ```
 

--- a/issues/029-timer-expiry-and-notification-interface.md
+++ b/issues/029-timer-expiry-and-notification-interface.md
@@ -1,0 +1,67 @@
+# 029 — Timer expiry + NotificationSource interface
+
+## Parent PRD
+
+PRD.md §FR7 (configuration) + §FR3 (pig UI)
+
+## What to build
+
+Detect when a focus timer expires and introduce a composable notification interface that any subsystem can implement.
+
+### `NotificationSource` trait (`crates/domain/src/notification.rs`)
+
+```rust
+pub trait NotificationSource {
+    fn key(&self) -> &'static str;   // stable identifier used in settings
+    fn label(&self) -> &'static str; // human-readable name for settings UI
+}
+
+pub struct NotificationSettings {
+    pub sources: std::collections::HashMap<String, bool>,
+}
+
+impl NotificationSettings {
+    pub fn is_enabled(&self, source: &dyn NotificationSource) -> bool {
+        *self.sources.get(source.key()).unwrap_or(&true)
+    }
+}
+```
+
+- `Settings` gains `notifications: NotificationSettings`
+- `settings.yaml` gains a `notifications:` section; missing keys default to `true`
+
+### Expiry detection
+
+- Background task (or existing tick) calls `timer_remaining_secs` for each focus with a `Running` timer
+- On transition to zero: sets `timer.status = Expired`, persists change
+- Emits Tauri event `timer-expired` with payload `{ focus_id, focus_title }`
+- If `NotificationSettings::is_enabled(TimerExpiredSource)` → fires system notification via Tauri
+
+### `TimerExpiredSource`
+
+```rust
+pub struct TimerExpiredSource;
+impl NotificationSource for TimerExpiredSource {
+    fn key(&self) -> &'static str { "timer_expired" }
+    fn label(&self) -> &'static str { "Timer expired" }
+}
+```
+
+## Completion promise
+
+When a focus timer reaches zero, `TimerStatus` transitions to `Expired`, a Tauri event fires, and a system notification appears (if enabled). Other subsystems can implement `NotificationSource` to plug into the same settings toggle.
+
+## Acceptance criteria
+
+- [ ] `NotificationSource` trait and `NotificationSettings` in `crates/domain/src/notification.rs`
+- [ ] `Settings::notifications` field; round-trips through `settings.yaml`
+- [ ] `TimerExpiredSource` implements `NotificationSource`
+- [ ] Background task detects expiry and sets `TimerStatus::Expired` exactly once per timer
+- [ ] Tauri event `timer-expired` emitted with `focus_id` and `focus_title`
+- [ ] System notification fires when `timer_expired` source is enabled
+- [ ] No notification when source disabled in settings
+- [ ] `task check` green
+
+## Blocked by
+
+028 (FocusTimer domain types)

--- a/issues/030-pig-growth-expired-visual-tray-list.md
+++ b/issues/030-pig-growth-expired-visual-tray-list.md
@@ -11,10 +11,12 @@ Visual feedback for timer state: pigs grow as their timer runs down, show a dist
 ### Pig scale growth
 
 - `src/hooks/usePigScale.ts` — pure function hook:
+
   ```ts
   export function usePigScale(startedAt: number | null, durationSecs: number | null): number
   // Returns 1.0 if no timer. Otherwise pig_scale(elapsed, duration) clamped 1.0–3.0.
   ```
+
 - Pig component multiplies `PIG_SIZE` by scale each render frame
 - Scale recomputed from `Date.now()` each rAF tick — no new `PigState` fields
 

--- a/issues/030-pig-growth-expired-visual-tray-list.md
+++ b/issues/030-pig-growth-expired-visual-tray-list.md
@@ -1,0 +1,52 @@
+# 030 — Pig scale growth + expired visual + tray expired list
+
+## Parent PRD
+
+PRD.md §FR3 (pig UI)
+
+## What to build
+
+Visual feedback for timer state: pigs grow as their timer runs down, show a distinct expired style, and expired focuses are listed in the tray.
+
+### Pig scale growth
+
+- `src/hooks/usePigScale.ts` — pure function hook:
+  ```ts
+  export function usePigScale(startedAt: number | null, durationSecs: number | null): number
+  // Returns 1.0 if no timer. Otherwise pig_scale(elapsed, duration) clamped 1.0–3.0.
+  ```
+- Pig component multiplies `PIG_SIZE` by scale each render frame
+- Scale recomputed from `Date.now()` each rAF tick — no new `PigState` fields
+
+### Expired pig visual
+
+- When `timer.status === 'Expired'`: pig renders with red tint (CSS `filter: hue-rotate` or overlay)
+- Subtle pulse/shake animation on expiry (CSS keyframe, one-shot on status change)
+- `PigDetail` shows timer status + remaining time (or "Expired")
+
+### Tray expired list
+
+- Tray menu section **"Expired"** lists focus titles whose timer status is `Expired`
+- Shown below active focuses, separated by a menu divider
+- Each item is read-only (clicking opens PigDetail or does nothing — designer choice)
+- Section hidden when no expired focuses
+
+## Completion promise
+
+Pigs with timers visually grow over their timer window; expired pigs are visually distinct; expired focuses appear in a dedicated tray section.
+
+## Acceptance criteria
+
+- [ ] `usePigScale` returns 1.0 for no-timer focuses
+- [ ] Pig renders larger as elapsed time increases toward `duration_secs`
+- [ ] Pig reaches ~3× base size at or after timer end
+- [ ] Expired pig has distinct visual style (red tint)
+- [ ] Expiry animation plays once on status change
+- [ ] `PigDetail` shows "Expired" or remaining `mm:ss`
+- [ ] Tray lists expired focuses under a divider; section absent when none
+- [ ] `task check` green
+
+## Blocked by
+
+028 (FocusTimer + pig_scale domain types)
+029 (timer-expired Tauri event for expiry animation trigger)

--- a/issues/031-notification-settings-tray.md
+++ b/issues/031-notification-settings-tray.md
@@ -1,0 +1,45 @@
+# 031 — Notification settings in tray
+
+## Parent PRD
+
+PRD.md §FR7 (configuration)
+
+## What to build
+
+Expose per-source notification toggles in the tray menu, using the `NotificationSource` interface from 029. Designed to slot into the future settings window (026) without rework.
+
+### Tray structure
+
+```
+Settings
+  ├── Displays          (existing)
+  ├── Window
+  │     └── Always on Top  (existing)
+  └── Notifications
+        └── Timer expired  ✓/✗  (toggleable, sourced from TimerExpiredSource::label())
+```
+
+- Toggle reads/writes `NotificationSettings::sources["timer_expired"]`
+- Persists immediately to `settings.yaml`
+- Adding a new `NotificationSource` implementation automatically appears here — no hardcoded list
+
+### Implementation note
+
+The tray submenu builder should iterate registered `NotificationSource` implementations (or a static list for now) rather than hardcoding menu items. This makes the submenu extensible when new sources are added.
+
+## Completion promise
+
+User can enable/disable timer expiry notifications from the tray without editing `settings.yaml`. The mechanism is generic enough that new notification sources appear automatically.
+
+## Acceptance criteria
+
+- [ ] Tray → Settings → Notifications submenu exists
+- [ ] "Timer expired" toggle reflects current `notifications.sources["timer_expired"]` value
+- [ ] Toggling updates `settings.yaml` and takes effect immediately (no restart needed)
+- [ ] Existing Settings submenus (Displays, Window) unaffected
+- [ ] Adding a second `NotificationSource` requires no changes to tray menu builder
+- [ ] `task check` green
+
+## Blocked by
+
+029 (NotificationSource trait + NotificationSettings in domain)

--- a/issues/031-notification-settings-tray.md
+++ b/issues/031-notification-settings-tray.md
@@ -10,7 +10,7 @@ Expose per-source notification toggles in the tray menu, using the `Notification
 
 ### Tray structure
 
-```
+```text
 Settings
   ├── Displays          (existing)
   ├── Window

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -80,6 +80,7 @@ pub fn run() {
             queue.clone(),
             decision_log.clone(),
             Arc::new(now_rfc3339),
+            Arc::new(now_unix_secs),
             Arc::new(|| uuid::Uuid::now_v7().to_string()),
             settings.clone(),
         ));
@@ -183,6 +184,10 @@ fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_default()
+}
+
+fn now_unix_secs() -> i64 {
+    time::OffsetDateTime::now_utc().unix_timestamp()
 }
 
 fn load_settings(path: &std::path::Path) -> Settings {

--- a/src-tauri/src/ui_bridge/mod.rs
+++ b/src-tauri/src/ui_bridge/mod.rs
@@ -42,6 +42,7 @@ pub fn list_proposals(state: State<'_, CommandsState>) -> Result<Vec<Proposal>, 
 pub fn create_focus(
     title: String,
     description: Option<String>,
+    timer_preset: Option<adhd_ranch_domain::TimerPreset>,
     state: State<'_, CommandsState>,
 ) -> Result<CreatedFocus, CommandError> {
     state
@@ -49,6 +50,7 @@ pub fn create_focus(
         .create_focus(CreateFocusInput {
             title: title.clone(),
             description: description.unwrap_or_default(),
+            timer_preset,
         })
         .inspect(|f| log::info!("focus created: {}", f.id))
         .inspect_err(|e| log::error!("create_focus({title:?}): {e}"))

--- a/src/api/focusWriter.ts
+++ b/src/api/focusWriter.ts
@@ -1,8 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { CommandError } from "../types/error";
+import type { TimerPreset } from "../types/timer";
 
 export interface FocusWriter {
-  createFocus(input: { title: string; description?: string }): Promise<{ id: string }>;
+  createFocus(input: {
+    title: string;
+    description?: string;
+    timer_preset?: TimerPreset | null;
+  }): Promise<{ id: string }>;
   deleteFocus(focusId: string): Promise<void>;
   appendTask(focusId: string, text: string): Promise<void>;
   deleteTask(focusId: string, index: number): Promise<void>;
@@ -17,10 +22,12 @@ function logErr(op: string) {
 
 export function createTauriFocusWriter(): FocusWriter {
   return {
-    createFocus({ title, description }) {
-      return invoke<{ id: string }>("create_focus", { title, description }).catch(
-        logErr("create_focus"),
-      );
+    createFocus({ title, description, timer_preset }) {
+      return invoke<{ id: string }>("create_focus", {
+        title,
+        description,
+        timerPreset: timer_preset ?? null,
+      }).catch(logErr("create_focus"));
     },
     deleteFocus(focusId: string) {
       return invoke<void>("delete_focus", { focusId }).catch(logErr("delete_focus"));

--- a/src/components/NewFocusForm.test.tsx
+++ b/src/components/NewFocusForm.test.tsx
@@ -21,7 +21,7 @@ describe("NewFocusForm", () => {
     expect(onCreate).not.toHaveBeenCalled();
   });
 
-  it("calls onCreate with trimmed title and description", async () => {
+  it("calls onCreate with trimmed title, description, and null timer by default", async () => {
     const onCreate = vi.fn().mockResolvedValue(undefined);
     render(<NewFocusForm onCreate={onCreate} />);
     fireEvent.click(screen.getByTestId("new-focus-toggle"));
@@ -36,6 +36,60 @@ describe("NewFocusForm", () => {
       expect(onCreate).toHaveBeenCalledWith({
         title: "Customer X bug",
         description: "ship",
+        timer_preset: null,
+      });
+    });
+  });
+
+  it("passes selected preset to onCreate", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    render(<NewFocusForm onCreate={onCreate} />);
+    fireEvent.click(screen.getByTestId("new-focus-toggle"));
+    fireEvent.change(screen.getByLabelText("new focus title"), {
+      target: { value: "Timer focus" },
+    });
+    fireEvent.change(screen.getByTestId("timer-preset-select"), {
+      target: { value: "Eight" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        title: "Timer focus",
+        description: "",
+        timer_preset: "Eight",
+      });
+    });
+  });
+
+  it("shows custom input when custom preset selected", () => {
+    render(<NewFocusForm onCreate={() => Promise.resolve()} />);
+    fireEvent.click(screen.getByTestId("new-focus-toggle"));
+    expect(screen.queryByTestId("custom-timer-input")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("timer-preset-select"), {
+      target: { value: "custom" },
+    });
+    expect(screen.getByTestId("custom-timer-input")).toBeInTheDocument();
+  });
+
+  it("passes Custom preset with minutes to onCreate", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    render(<NewFocusForm onCreate={onCreate} />);
+    fireEvent.click(screen.getByTestId("new-focus-toggle"));
+    fireEvent.change(screen.getByLabelText("new focus title"), {
+      target: { value: "Custom timer" },
+    });
+    fireEvent.change(screen.getByTestId("timer-preset-select"), {
+      target: { value: "custom" },
+    });
+    fireEvent.change(screen.getByTestId("custom-timer-input"), {
+      target: { value: "45" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        title: "Custom timer",
+        description: "",
+        timer_preset: { Custom: 45 },
       });
     });
   });

--- a/src/components/NewFocusForm.tsx
+++ b/src/components/NewFocusForm.tsx
@@ -61,7 +61,10 @@ export function NewFocusForm({ onCreate }: NewFocusFormProps) {
       setError("title is required");
       return;
     }
-    if (timerSelect === "custom" && (customMinutes < 1 || !Number.isFinite(customMinutes))) {
+    if (
+      timerSelect === "custom" &&
+      (customMinutes < 1 || !Number.isFinite(customMinutes) || !Number.isInteger(customMinutes))
+    ) {
       setError("custom timer must be at least 1 minute");
       return;
     }

--- a/src/components/NewFocusForm.tsx
+++ b/src/components/NewFocusForm.tsx
@@ -1,13 +1,25 @@
 import { useState } from "react";
 
+import type { TimerPreset } from "../types/timer";
+
+type SelectValue = "none" | "Two" | "Four" | "Eight" | "Sixteen" | "ThirtyTwo" | "custom";
+
+export interface NewFocusFormInput {
+  readonly title: string;
+  readonly description: string;
+  readonly timer_preset: TimerPreset | null;
+}
+
 export interface NewFocusFormProps {
-  readonly onCreate: (input: { title: string; description: string }) => Promise<void>;
+  readonly onCreate: (input: NewFocusFormInput) => Promise<void>;
 }
 
 export function NewFocusForm({ onCreate }: NewFocusFormProps) {
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [timerSelect, setTimerSelect] = useState<SelectValue>("none");
+  const [customMinutes, setCustomMinutes] = useState(10);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,18 +36,47 @@ export function NewFocusForm({ onCreate }: NewFocusFormProps) {
     );
   }
 
+  function resolvePreset(): TimerPreset | null {
+    switch (timerSelect) {
+      case "Two":
+        return "Two";
+      case "Four":
+        return "Four";
+      case "Eight":
+        return "Eight";
+      case "Sixteen":
+        return "Sixteen";
+      case "ThirtyTwo":
+        return "ThirtyTwo";
+      case "custom":
+        return { Custom: customMinutes };
+      default:
+        return null;
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (title.trim().length === 0) {
       setError("title is required");
       return;
     }
+    if (timerSelect === "custom" && (customMinutes < 1 || !Number.isFinite(customMinutes))) {
+      setError("custom timer must be at least 1 minute");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
-      await onCreate({ title: title.trim(), description: description.trim() });
+      await onCreate({
+        title: title.trim(),
+        description: description.trim(),
+        timer_preset: resolvePreset(),
+      });
       setTitle("");
       setDescription("");
+      setTimerSelect("none");
+      setCustomMinutes(10);
       setOpen(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -62,6 +103,32 @@ export function NewFocusForm({ onCreate }: NewFocusFormProps) {
         onChange={(e) => setDescription(e.target.value)}
         disabled={submitting}
       />
+      <select
+        aria-label="timer preset"
+        data-testid="timer-preset-select"
+        value={timerSelect}
+        onChange={(e) => setTimerSelect(e.target.value as SelectValue)}
+        disabled={submitting}
+      >
+        <option value="none">No timer</option>
+        <option value="Two">2m</option>
+        <option value="Four">4m</option>
+        <option value="Eight">8m</option>
+        <option value="Sixteen">16m</option>
+        <option value="ThirtyTwo">32m</option>
+        <option value="custom">Custom</option>
+      </select>
+      {timerSelect === "custom" && (
+        <input
+          type="number"
+          aria-label="custom timer minutes"
+          data-testid="custom-timer-input"
+          min={1}
+          value={customMinutes}
+          onChange={(e) => setCustomMinutes(Number(e.target.value))}
+          disabled={submitting}
+        />
+      )}
       <div className="new-focus-actions">
         <button type="submit" disabled={submitting}>
           Create

--- a/src/types/timer.ts
+++ b/src/types/timer.ts
@@ -1,0 +1,21 @@
+export type TimerPresetVariant = "Two" | "Four" | "Eight" | "Sixteen" | "ThirtyTwo";
+
+export type TimerPreset = TimerPresetVariant | { Custom: number }; // minutes
+
+export type TimerStatus = "Running" | "Expired";
+
+export interface FocusTimer {
+  readonly duration_secs: number;
+  readonly started_at: number;
+  readonly status: TimerStatus;
+}
+
+export const PRESET_OPTIONS: Array<{ label: string; value: TimerPreset | null }> = [
+  { label: "No timer", value: null },
+  { label: "2m", value: "Two" },
+  { label: "4m", value: "Four" },
+  { label: "8m", value: "Eight" },
+  { label: "16m", value: "Sixteen" },
+  { label: "32m", value: "ThirtyTwo" },
+  { label: "Custom", value: null }, // placeholder — custom uses number input
+];


### PR DESCRIPTION
## Issue

[issues/028-focus-timer-domain-and-creation.md](issues/028-focus-timer-domain-and-creation.md)

## Completion promise

User can create a focus with a timer preset; the timer is stored and readable via the API with correct remaining time.

## Changes

- `crates/domain/src/timer.rs` — pure domain: `FocusTimer`, `TimerPreset` (2/4/8/16/32m + Custom), `TimerStatus`, `timer_remaining_secs()`, `growth_factor()` with 10 unit tests
- `Focus.timer: Option<FocusTimer>`, `NewFocus.timer_preset: Option<TimerPreset>`
- `FocusStore::create_focus` accepts `Option<FocusTimer>`; persists to `timer.json` sidecar alongside `focus.md`; `list()` reads sidecar back into `Focus.timer`
- `Commands` gains injected `ClockSecs` dep for deterministic `started_at` in tests
- `create_focus` builds `FocusTimer` from preset + `clock_secs` when preset present
- `NewFocusForm`: timer dropdown (None / 2m / 4m / 8m / 16m / 32m / Custom) + custom number input; passes `timer_preset` through `onCreate` callback
- `src/types/timer.ts`: `TimerPreset`, `FocusTimer`, `TimerStatus` TS types
- `focusWriter.ts`: `createFocus` accepts and forwards `timer_preset`

## Test plan

- [ ] `task check` green (127 Rust + 61 frontend tests)
- [ ] Create focus with each preset — timer stored with correct `duration_secs`
- [ ] Create focus without preset — `timer: null` in response
- [ ] Custom preset stores `duration_secs = minutes * 60`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add optional timer presets when creating focuses (2,4,8,16,32 minutes or Custom) with form UI and custom-minute input.
  * Timers persist with focuses; creating a timed focus starts a running timer.
  * Pig growth scales with timer progress; expired focuses show an expired visual and appear in an "Expired" tray section.
  * Notification settings added to control timer-expiry alerts.

* **Improvements**
  * Consistent serialization and round-trip behavior for timer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->