### PR TITLE
[033-pig-ipc-api-layer]: Extract pig/drag IPC into api/ layer

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,10 +1,5 @@
 version: "3"
 
-includes:
-  ralph:
-    taskfile: ralph/Taskfile.yaml
-    dir: '{{.ROOT_DIR}}'
-
 tasks:
   default:
     desc: List available tasks

--- a/src/api/pig.ts
+++ b/src/api/pig.ts
@@ -1,0 +1,23 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { PigHitRect, SpawnRegion } from "../types/pig";
+
+export type Unsubscribe = () => void;
+
+export async function setPigDragActive(active: boolean): Promise<void> {
+  await invoke("set_pig_drag_active", { active });
+}
+
+export async function updatePigRects(rects: readonly PigHitRect[]): Promise<void> {
+  await invoke("update_pig_rects", { rects });
+}
+
+export async function subscribeGatherPigs(cb: () => void): Promise<Unsubscribe> {
+  return listen("gather-pigs", () => cb());
+}
+
+export async function subscribeDisplayRegion(
+  cb: (region: SpawnRegion) => void,
+): Promise<Unsubscribe> {
+  return listen<SpawnRegion>("display-region", (event) => cb(event.payload));
+}

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -34,8 +34,7 @@ vi.mock(import("../hooks/usePigMovement"), async (importOriginal) => {
       startDrag: vi.fn(),
       moveDrag: vi.fn(),
       endDrag: vi.fn(() => ({ wasDrag: false })),
-      gather: vi.fn(),
-      setRegion: vi.fn(),
+      setDragActive: vi.fn(),
     }),
   };
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,10 @@
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import type { FocusWriter } from "../api/focusWriter";
 import type { FocusReader } from "../api/focuses";
+import { setPigDragActive, subscribeDisplayRegion, subscribeGatherPigs } from "../api/pig";
 import { useDebugOverlay } from "../hooks/useDebugOverlay";
 import { useFocuses } from "../hooks/useFocuses";
-import { type SpawnRegion, usePigMovement } from "../hooks/usePigMovement";
+import { usePigMovement } from "../hooks/usePigMovement";
 import { useViewport } from "../hooks/useViewport";
 import { PigDetail } from "./PigDetail";
 import { PigSprite } from "./PigSprite";
@@ -27,22 +26,22 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const { visible: showDebug, topOffset: debugTopOffset } = useDebugOverlay();
 
   const handleSetDragActive = useCallback((active: boolean) => {
-    invoke("set_pig_drag_active", { active }).catch(() => {});
+    setPigDragActive(active).catch(() => {});
   }, []);
 
   useEffect(() => {
-    const unlistenPromise = listen("gather-pigs", gather);
+    // If subscribe rejects, fall back to a no-op unsubscribe so cleanup never throws
+    // an unhandled rejection during React strict-mode unmounts.
+    const unsubPromise = subscribeGatherPigs(gather).catch(() => () => {});
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      unsubPromise.then((unsub) => unsub());
     };
   }, [gather]);
 
   useEffect(() => {
-    const unlistenPromise = listen<SpawnRegion>("display-region", (event) => {
-      setRegion(event.payload);
-    });
+    const unsubPromise = subscribeDisplayRegion(setRegion).catch(() => () => {});
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      unsubPromise.then((unsub) => unsub());
     };
   }, [setRegion]);
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import type { FocusWriter } from "../api/focusWriter";
 import type { FocusReader } from "../api/focuses";
-import { setPigDragActive, subscribeDisplayRegion, subscribeGatherPigs } from "../api/pig";
 import { useDebugOverlay } from "../hooks/useDebugOverlay";
 import { useFocuses } from "../hooks/useFocuses";
 import { usePigMovement } from "../hooks/usePigMovement";
@@ -18,32 +17,9 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const focusState = useFocuses(focusReader);
   const focuses = focusState.status === "ready" ? focusState.focuses : [];
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const { pigs, startDrag, moveDrag, endDrag, gather, setRegion } = usePigMovement(
-    focuses,
-    selectedId,
-  );
+  const { pigs, startDrag, moveDrag, endDrag, setDragActive } = usePigMovement(focuses, selectedId);
   const { screenW, screenH } = useViewport();
   const { visible: showDebug, topOffset: debugTopOffset } = useDebugOverlay();
-
-  const handleSetDragActive = useCallback((active: boolean) => {
-    setPigDragActive(active).catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    // If subscribe rejects, fall back to a no-op unsubscribe so cleanup never throws
-    // an unhandled rejection during React strict-mode unmounts.
-    const unsubPromise = subscribeGatherPigs(gather).catch(() => () => {});
-    return () => {
-      unsubPromise.then((unsub) => unsub());
-    };
-  }, [gather]);
-
-  useEffect(() => {
-    const unsubPromise = subscribeDisplayRegion(setRegion).catch(() => () => {});
-    return () => {
-      unsubPromise.then((unsub) => unsub());
-    };
-  }, [setRegion]);
 
   const selectedPig = pigs.find((p) => p.id === selectedId);
   const selectedFocus = focuses.find((f) => f.id === selectedId);
@@ -99,7 +75,7 @@ export function App({ focusReader, focusWriter }: AppProps) {
           onDragStart={(x, y) => startDrag(pig.id, x, y)}
           onDragMove={moveDrag}
           onDragEnd={endDrag}
-          onSetDragActive={handleSetDragActive}
+          onSetDragActive={setDragActive}
         />
       ))}
       {selectedPig && selectedFocus && (

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { updatePigRects } from "../api/pig";
+import {
+  setPigDragActive,
+  subscribeDisplayRegion,
+  subscribeGatherPigs,
+  updatePigRects,
+} from "../api/pig";
 import type { Focus } from "../types/focus";
 import type { PigHitRect, SpawnRegion } from "../types/pig";
 
@@ -68,8 +73,7 @@ export interface PigMovementResult {
   startDrag: (pigId: string, x: number, y: number) => void;
   moveDrag: (x: number, y: number) => void;
   endDrag: () => { wasDrag: boolean };
-  gather: () => void;
-  setRegion: (r: SpawnRegion) => void;
+  setDragActive: (active: boolean) => void;
 }
 
 function direction4(vx: number, vy: number): PigDirection {
@@ -241,6 +245,10 @@ export function usePigMovement(
     regionRef.current = r;
   }, []);
 
+  const setDragActive = useCallback((active: boolean) => {
+    setPigDragActive(active).catch(() => {});
+  }, []);
+
   const startDrag = useCallback((pigId: string, x: number, y: number) => {
     dragIdRef.current = pigId;
     dragStartRef.current = { x, y };
@@ -331,6 +339,22 @@ export function usePigMovement(
     });
   }, [focuses]);
 
+  // Subscribe to gather-pigs / display-region events from Rust.
+  // Fall back to a no-op unsubscribe if subscribe rejects so cleanup never throws.
+  useEffect(() => {
+    const unsubPromise = subscribeGatherPigs(gather).catch(() => () => {});
+    return () => {
+      unsubPromise.then((unsub) => unsub());
+    };
+  }, [gather]);
+
+  useEffect(() => {
+    const unsubPromise = subscribeDisplayRegion(setRegion).catch(() => () => {});
+    return () => {
+      unsubPromise.then((unsub) => unsub());
+    };
+  }, [setRegion]);
+
   // rAF movement loop
   useEffect(() => {
     const loop = (now: number) => {
@@ -362,5 +386,5 @@ export function usePigMovement(
     return () => cancelAnimationFrame(rafRef.current);
   }, []);
 
-  return { pigs, startDrag, moveDrag, endDrag, gather, setRegion };
+  return { pigs, startDrag, moveDrag, endDrag, setDragActive };
 }

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -1,6 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { updatePigRects } from "../api/pig";
 import type { Focus } from "../types/focus";
+import type { PigHitRect, SpawnRegion } from "../types/pig";
+
+export type { PigHitRect, SpawnRegion };
 
 export const PIG_SIZE = 48;
 export const HITBOX_PADDING = 16;
@@ -12,12 +15,6 @@ export const PIG_SPEED = 60; // px/s — fast enough to look alive across large 
 const MIN_SPEED_FRAC = 0.35; // friction floor: never drop below this fraction of PIG_SPEED
 const EDGE_MARGIN = 60; // px from screen edge
 
-export interface SpawnRegion {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
 const FRAME_INTERVAL = 150; // ms per animation frame
 const MIN_TURN_MS = 3000;
 const MAX_TURN_MS = 8000;
@@ -196,12 +193,6 @@ function tickPig(
   return { ...pig, x, y, vx, vy, frameIndex, direction, lastFrameAt, nextTurnAt };
 }
 
-export interface PigHitRect {
-  x: number;
-  y: number;
-  size: number;
-}
-
 export function buildHitRects(pigs: PigState[], dpr: number): PigHitRect[] {
   return pigs.map((p) => ({
     x: (p.x - HITBOX_PADDING / 2) * dpr,
@@ -216,7 +207,7 @@ function syncRects(pigs: PigState[], wide: boolean): void {
   const rects = wide
     ? [{ x: 0, y: 0, size: Math.max(window.innerWidth, window.innerHeight) * dpr * 2 }]
     : buildHitRects(pigs, dpr);
-  invoke("update_pig_rects", { rects }).catch(() => {});
+  updatePigRects(rects).catch(() => {});
 }
 
 function defaultRegion(): SpawnRegion {

--- a/src/types/pig.ts
+++ b/src/types/pig.ts
@@ -1,0 +1,12 @@
+export interface SpawnRegion {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PigHitRect {
+  x: number;
+  y: number;
+  size: number;
+}


### PR DESCRIPTION
Closes [issues/033-pig-ipc-api-layer.md](issues/033-pig-ipc-api-layer.md)

> **Completion promise:** No `invoke` or `listen` calls remain in `src/components/` or `src/hooks/`; all pig/drag IPC lives in `src/api/pig.ts`.

## Summary
- New `src/api/pig.ts` exports four typed wrappers: `setPigDragActive`, `updatePigRects`, `subscribeGatherPigs`, `subscribeDisplayRegion`
- New `src/types/pig.ts` shares `SpawnRegion` and `PigHitRect` so `api/` does not depend on `hooks/`
- `App.tsx` and `usePigMovement.ts` drop direct tauri `invoke`/`listen`; subscriptions wrap a no-op fallback so cleanup cannot throw an unhandled rejection on strict-mode unmount
- Drop stale `ralph/` Taskfile include left over from dabed05

## Test plan
- [x] `task check` green
- [x] No `invoke`/`listen` in production code under `src/components` or `src/hooks` (remaining grep hits are test mocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved pig-related native interactions into a dedicated client API and centralized related type definitions.
  * Updated pig movement hook to expose a drag-control handler and subscribe to native pig/gathering events.

* **Tests**
  * Aligned component tests with the updated pig movement API.

* **Chores**
  * Removed an unused taskfile inclusion from build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->