### PR TITLE
[035-focus-store-unit-tests]: Unit tests for MarkdownFocusStore

### DIFF
--- a/crates/storage/src/focus_store.rs
+++ b/crates/storage/src/focus_store.rs
@@ -418,11 +418,7 @@ mod tests {
 
         let slug = store
             .create_focus(
-                &NewFocus {
-                    title: "Customer X bug".into(),
-                    description: "ship it".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("Customer X bug", "ship it").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,
@@ -452,11 +448,7 @@ mod tests {
 
         store
             .create_focus(
-                &NewFocus {
-                    title: "With timer".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("With timer", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 Some(timer.clone()),
@@ -475,11 +467,7 @@ mod tests {
 
         store
             .create_focus(
-                &NewFocus {
-                    title: "No timer".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("No timer", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,
@@ -497,11 +485,7 @@ mod tests {
         let store = MarkdownFocusStore::new(dir.path());
         let slug = store
             .create_focus(
-                &NewFocus {
-                    title: "Bye".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("Bye", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,
@@ -528,11 +512,7 @@ mod tests {
         let store = MarkdownFocusStore::new(dir.path());
         let slug = store
             .create_focus(
-                &NewFocus {
-                    title: "Broken timer".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("Broken timer", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,
@@ -554,11 +534,7 @@ mod tests {
         let store = MarkdownFocusStore::new(dir.path());
         let slug = store
             .create_focus(
-                &NewFocus {
-                    title: "Has tasks".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("Has tasks", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,
@@ -579,11 +555,7 @@ mod tests {
         let store = MarkdownFocusStore::new(dir.path());
         let slug = store
             .create_focus(
-                &NewFocus {
-                    title: "Two tasks".into(),
-                    description: "".into(),
-                    timer_preset: None,
-                },
+                &NewFocus::new("Two tasks", "").unwrap(),
                 "id-1",
                 "2026-04-30T12:00:00Z",
                 None,

--- a/crates/storage/src/focus_store.rs
+++ b/crates/storage/src/focus_store.rs
@@ -111,10 +111,11 @@ impl FocusStore for MarkdownFocusStore {
             let timer_path = entry.path().join("timer.json");
             if timer_path.is_file() {
                 let raw = fs::read_to_string(&timer_path)?;
-                focus.timer = Some(
-                    serde_json::from_str(&raw)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                );
+                // A corrupted timer.json must not take down list() — the focus
+                // itself is still readable and useful. Surface as `timer: None`
+                // so the UI degrades gracefully; user can fix the sidecar by
+                // recreating the focus.
+                focus.timer = serde_json::from_str(&raw).ok();
             }
             out.push(focus);
         }
@@ -404,5 +405,197 @@ mod tests {
         let store = MarkdownFocusStore::new(dir.path());
         let err = store.delete_focus("missing").unwrap_err();
         assert!(matches!(err, FocusStoreError::NotFound(_)));
+    }
+
+    // Issue 035: direct unit-test coverage for the create/list/delete/task
+    // mutation cycle and timer sidecar edge cases. Names mirror the spec's
+    // acceptance table; each test exercises only public store API.
+
+    #[test]
+    fn create_then_list_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+
+        let slug = store
+            .create_focus(
+                &NewFocus {
+                    title: "Customer X bug".into(),
+                    description: "ship it".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+
+        let focuses = store.list().unwrap();
+
+        assert_eq!(focuses.len(), 1);
+        let f = &focuses[0];
+        assert_eq!(f.id, adhd_ranch_domain::FocusId(slug));
+        assert_eq!(f.title, "Customer X bug");
+        assert_eq!(f.description, "ship it");
+        assert_eq!(f.created_at, "2026-04-30T12:00:00Z");
+        assert!(f.timer.is_none());
+    }
+
+    #[test]
+    fn list_with_timer_sidecar() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let timer = FocusTimer {
+            duration_secs: 240,
+            started_at: 1_700_000_000,
+            status: adhd_ranch_domain::TimerStatus::Running,
+        };
+
+        store
+            .create_focus(
+                &NewFocus {
+                    title: "With timer".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                Some(timer.clone()),
+            )
+            .unwrap();
+
+        let focuses = store.list().unwrap();
+        assert_eq!(focuses.len(), 1);
+        assert_eq!(focuses[0].timer, Some(timer));
+    }
+
+    #[test]
+    fn list_without_timer_sidecar() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+
+        store
+            .create_focus(
+                &NewFocus {
+                    title: "No timer".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+
+        let focuses = store.list().unwrap();
+        assert_eq!(focuses.len(), 1);
+        assert!(focuses[0].timer.is_none());
+    }
+
+    #[test]
+    fn delete_removes_directory() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let slug = store
+            .create_focus(
+                &NewFocus {
+                    title: "Bye".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+        assert!(dir.path().join(&slug).is_dir());
+
+        store.delete_focus(&slug).unwrap();
+
+        assert!(!dir.path().join(&slug).exists());
+    }
+
+    #[test]
+    fn delete_nonexistent_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let err = store.delete_focus("ghost").unwrap_err();
+        assert!(matches!(err, FocusStoreError::NotFound(slug) if slug == "ghost"));
+    }
+
+    #[test]
+    fn corrupted_timer_json_degrades_gracefully() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let slug = store
+            .create_focus(
+                &NewFocus {
+                    title: "Broken timer".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+        let timer_path = dir.path().join(&slug).join("timer.json");
+        fs::write(&timer_path, b"{ this is not valid json").unwrap();
+
+        let focuses = store.list().unwrap();
+
+        assert_eq!(focuses.len(), 1);
+        assert_eq!(focuses[0].title, "Broken timer");
+        assert!(focuses[0].timer.is_none());
+    }
+
+    #[test]
+    fn append_task_persists() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let slug = store
+            .create_focus(
+                &NewFocus {
+                    title: "Has tasks".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+
+        store.append_task(&slug, "first thing").unwrap();
+
+        let focuses = store.list().unwrap();
+        assert_eq!(focuses.len(), 1);
+        assert_eq!(focuses[0].tasks.len(), 1);
+        assert_eq!(focuses[0].tasks[0].text, "first thing");
+    }
+
+    #[test]
+    fn delete_task_persists() {
+        let dir = TempDir::new().unwrap();
+        let store = MarkdownFocusStore::new(dir.path());
+        let slug = store
+            .create_focus(
+                &NewFocus {
+                    title: "Two tasks".into(),
+                    description: "".into(),
+                    timer_preset: None,
+                },
+                "id-1",
+                "2026-04-30T12:00:00Z",
+                None,
+            )
+            .unwrap();
+        store.append_task(&slug, "keep me").unwrap();
+        store.append_task(&slug, "remove me").unwrap();
+
+        store.delete_task(&slug, 1).unwrap();
+
+        let focuses = store.list().unwrap();
+        assert_eq!(focuses[0].tasks.len(), 1);
+        assert_eq!(focuses[0].tasks[0].text, "keep me");
     }
 }


### PR DESCRIPTION
Closes [issues/035-focus-store-unit-tests.md](issues/035-focus-store-unit-tests.md)

> **Completion promise:** `MarkdownFocusStore` has direct unit tests covering the create/list/delete/task mutation cycle and timer sidecar edge cases; the storage seam is independently trusted without Commands.

## Summary
- 8 new unit tests in `focus_store.rs` covering the acceptance table
- All tests use `TempDir`; `corrupted_timer_json_degrades_gracefully` captures the slug returned by `create_focus` instead of hardcoding it
- `list()` degrades to `timer: None` on corrupted `timer.json` instead of failing the whole load
- Drop stale `ralph/` Taskfile include left over from dabed05

## Test plan
- [x] `cargo test -p adhd-ranch-storage` green in isolation
- [x] `task check` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Focus operations now gracefully handle corrupted timer configuration files, allowing the system to continue processing instead of failing entirely when timer data is malformed.

* **Tests**
  * Extended test coverage for focus management workflows, including creation, listing, and deletion with proper timer file handling and graceful degradation of corrupted configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->