### PR TITLE
[041-focus-writer-write-outcome]: FocusWriter returns WriteOutcome

### DIFF
--- a/src/api/fixtureFocusWriter.test.ts
+++ b/src/api/fixtureFocusWriter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createFixtureFocusWriter } from "./fixtureFocusWriter";
+
+describe("fixtureFocusWriter", () => {
+  it("returns ok:true by default", async () => {
+    const writer = createFixtureFocusWriter();
+
+    expect(await writer.appendTask("a", "x")).toEqual({ ok: true });
+    expect(await writer.createFocus({ title: "t" })).toEqual({ ok: true });
+  });
+
+  it("returns the injected failure", async () => {
+    const writer = createFixtureFocusWriter({
+      failure: { ok: false, kind: "domain", message: "boom" },
+    });
+
+    expect(await writer.appendTask("a", "x")).toEqual({
+      ok: false,
+      kind: "domain",
+      message: "boom",
+    });
+    expect(await writer.renameFocus("a", "n")).toEqual({
+      ok: false,
+      kind: "domain",
+      message: "boom",
+    });
+  });
+});

--- a/src/api/fixtureFocusWriter.ts
+++ b/src/api/fixtureFocusWriter.ts
@@ -1,0 +1,19 @@
+import type { FocusWriter, WriteOutcome } from "./focusWriter";
+
+export interface FixtureFocusWriterOptions {
+  readonly failure?: Extract<WriteOutcome, { ok: false }>;
+}
+
+export function createFixtureFocusWriter(opts: FixtureFocusWriterOptions = {}): FocusWriter {
+  const outcome: WriteOutcome = opts.failure ?? { ok: true };
+  const result = () => Promise.resolve(outcome);
+  return {
+    createFocus: result,
+    deleteFocus: result,
+    renameFocus: result,
+    appendTask: result,
+    deleteTask: result,
+    updateTask: result,
+    toggleTask: result,
+  };
+}

--- a/src/api/focusWriter.test.ts
+++ b/src/api/focusWriter.test.ts
@@ -1,0 +1,59 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTauriFocusWriter } from "./focusWriter";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const mockInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+});
+
+describe("tauriFocusWriter", () => {
+  it("appendTask returns ok:true when invoke resolves", async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+    const writer = createTauriFocusWriter();
+
+    const outcome = await writer.appendTask("focus-1", "do thing");
+
+    expect(outcome).toEqual({ ok: true });
+    expect(mockInvoke).toHaveBeenCalledWith("append_task", {
+      focusId: "focus-1",
+      text: "do thing",
+    });
+  });
+
+  it("appendTask returns ipc failure when invoke rejects with non-CommandError", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("transport blew up"));
+    const writer = createTauriFocusWriter();
+
+    const outcome = await writer.appendTask("focus-1", "x");
+
+    expect(outcome).toEqual({
+      ok: false,
+      kind: "ipc",
+      message: "transport blew up",
+    });
+  });
+
+  it("appendTask returns domain failure when invoke rejects with bad_request", async () => {
+    mockInvoke.mockRejectedValueOnce({ type: "bad_request", message: "empty task text" });
+    const writer = createTauriFocusWriter();
+
+    const outcome = await writer.appendTask("focus-1", "");
+
+    expect(outcome).toEqual({ ok: false, kind: "domain", message: "empty task text" });
+  });
+
+  it("appendTask returns not_found failure when invoke rejects with not_found", async () => {
+    mockInvoke.mockRejectedValueOnce({ type: "not_found", message: "focus missing: x" });
+    const writer = createTauriFocusWriter();
+
+    const outcome = await writer.appendTask("missing", "y");
+
+    expect(outcome).toEqual({ ok: false, kind: "not_found", message: "focus missing: x" });
+  });
+});

--- a/src/api/focusWriter.ts
+++ b/src/api/focusWriter.ts
@@ -1,54 +1,71 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { CommandError } from "../types/error";
 import type { TimerPreset } from "../types/timer";
 
-export interface FocusWriter {
-  createFocus(input: {
-    title: string;
-    description?: string;
-    timer_preset?: TimerPreset | null;
-  }): Promise<{ id: string }>;
-  deleteFocus(focusId: string): Promise<void>;
-  renameFocus(focusId: string, title: string): Promise<void>;
-  appendTask(focusId: string, text: string): Promise<void>;
-  deleteTask(focusId: string, index: number): Promise<void>;
-  updateTask(focusId: string, index: number, text: string): Promise<void>;
-  toggleTask(focusId: string, index: number, done: boolean): Promise<void>;
+export type WriteOutcome =
+  | { ok: true }
+  | { ok: false; kind: "ipc" | "domain" | "not_found"; message: string };
+
+export interface CreateFocusInput {
+  title: string;
+  description?: string;
+  timer_preset?: TimerPreset | null;
 }
 
-function logErr(op: string) {
-  return (e: unknown): never => {
-    console.error(`[adhd-ranch] ${op}`, e as CommandError);
-    throw e;
-  };
+export interface FocusWriter {
+  createFocus(input: CreateFocusInput): Promise<WriteOutcome>;
+  deleteFocus(focusId: string): Promise<WriteOutcome>;
+  renameFocus(focusId: string, title: string): Promise<WriteOutcome>;
+  appendTask(focusId: string, text: string): Promise<WriteOutcome>;
+  deleteTask(focusId: string, index: number): Promise<WriteOutcome>;
+  updateTask(focusId: string, index: number, text: string): Promise<WriteOutcome>;
+  toggleTask(focusId: string, index: number, done: boolean): Promise<WriteOutcome>;
+}
+
+function toFailure(e: unknown): WriteOutcome {
+  if (e && typeof e === "object" && "type" in e && "message" in e) {
+    const err = e as { type: string; message: string };
+    const kind = err.type === "not_found" ? "not_found" : "domain";
+    return { ok: false, kind, message: err.message };
+  }
+  const message = e instanceof Error ? e.message : String(e);
+  return { ok: false, kind: "ipc", message };
+}
+
+async function runInvoke(cmd: string, args: Record<string, unknown>): Promise<WriteOutcome> {
+  try {
+    await invoke<unknown>(cmd, args);
+    return { ok: true };
+  } catch (e) {
+    return toFailure(e);
+  }
 }
 
 export function createTauriFocusWriter(): FocusWriter {
   return {
     createFocus({ title, description, timer_preset }) {
-      return invoke<{ id: string }>("create_focus", {
+      return runInvoke("create_focus", {
         title,
         description,
         timerPreset: timer_preset ?? null,
-      }).catch(logErr("create_focus"));
+      });
     },
-    deleteFocus(focusId: string) {
-      return invoke<void>("delete_focus", { focusId }).catch(logErr("delete_focus"));
+    deleteFocus(focusId) {
+      return runInvoke("delete_focus", { focusId });
     },
-    appendTask(focusId: string, text: string) {
-      return invoke<void>("append_task", { focusId, text }).catch(logErr("append_task"));
+    appendTask(focusId, text) {
+      return runInvoke("append_task", { focusId, text });
     },
-    deleteTask(focusId: string, index: number) {
-      return invoke<void>("delete_task", { focusId, index }).catch(logErr("delete_task"));
+    deleteTask(focusId, index) {
+      return runInvoke("delete_task", { focusId, index });
     },
-    renameFocus(focusId: string, title: string) {
-      return invoke<void>("rename_focus", { focusId, title }).catch(logErr("rename_focus"));
+    renameFocus(focusId, title) {
+      return runInvoke("rename_focus", { focusId, title });
     },
-    updateTask(focusId: string, index: number, text: string) {
-      return invoke<void>("update_task", { focusId, index, text }).catch(logErr("update_task"));
+    updateTask(focusId, index, text) {
+      return runInvoke("update_task", { focusId, index, text });
     },
-    toggleTask(focusId: string, index: number, done: boolean) {
-      return invoke<void>("toggle_task", { focusId, index, done }).catch(logErr("toggle_task"));
+    toggleTask(focusId, index, done) {
+      return runInvoke("toggle_task", { focusId, index, done });
     },
   };
 }

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -59,12 +59,24 @@ function noopFocusWriter(): FocusWriter {
 
 describe("App overlay", () => {
   it("renders the overlay root", () => {
-    render(<App focusReader={createFixtureFocusReader([])} focusWriter={noopFocusWriter()} />);
+    render(
+      <App
+        focusReader={createFixtureFocusReader([])}
+        focusWriter={noopFocusWriter()}
+        onWriteFailure={() => {}}
+      />,
+    );
     expect(document.querySelector(".overlay-root")).toBeInTheDocument();
   });
 
   it("spawns a pig for each focus", async () => {
-    render(<App focusReader={createFixtureFocusReader(sample)} focusWriter={noopFocusWriter()} />);
+    render(
+      <App
+        focusReader={createFixtureFocusReader(sample)}
+        focusWriter={noopFocusWriter()}
+        onWriteFailure={() => {}}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText("Customer X bug")).toBeInTheDocument();
       expect(screen.getByText("API refactor")).toBeInTheDocument();
@@ -73,7 +85,13 @@ describe("App overlay", () => {
 
   it("add-task input calls focusWriter.appendTask with selected focus id", async () => {
     const writer = noopFocusWriter();
-    render(<App focusReader={createFixtureFocusReader(sample)} focusWriter={writer} />);
+    render(
+      <App
+        focusReader={createFixtureFocusReader(sample)}
+        focusWriter={writer}
+        onWriteFailure={() => {}}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Customer X bug")).toBeInTheDocument();

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -45,14 +45,15 @@ const sample: Focus[] = [
 ];
 
 function noopFocusWriter(): FocusWriter {
+  const ok = { ok: true } as const;
   return {
-    createFocus: vi.fn().mockResolvedValue({ id: "any" }),
-    deleteFocus: vi.fn().mockResolvedValue(undefined),
-    renameFocus: vi.fn().mockResolvedValue(undefined),
-    appendTask: vi.fn().mockResolvedValue(undefined),
-    deleteTask: vi.fn().mockResolvedValue(undefined),
-    updateTask: vi.fn().mockResolvedValue(undefined),
-    toggleTask: vi.fn().mockResolvedValue(undefined),
+    createFocus: vi.fn().mockResolvedValue(ok),
+    deleteFocus: vi.fn().mockResolvedValue(ok),
+    renameFocus: vi.fn().mockResolvedValue(ok),
+    appendTask: vi.fn().mockResolvedValue(ok),
+    deleteTask: vi.fn().mockResolvedValue(ok),
+    updateTask: vi.fn().mockResolvedValue(ok),
+    toggleTask: vi.fn().mockResolvedValue(ok),
   };
 }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { FocusWriter } from "../api/focusWriter";
+import type { FocusWriter, WriteOutcome } from "../api/focusWriter";
 import type { PolledReader } from "../api/polledReader";
 import { useConfirmDelete } from "../hooks/useConfirmDelete";
 import { useDebugOverlay } from "../hooks/useDebugOverlay";
@@ -27,54 +27,34 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const selectedPig = pigs.find((p) => p.id === selectedId);
   const selectedFocus = focuses.find((f) => f.id === selectedId);
 
+  function reportFailure(op: string, outcome: WriteOutcome) {
+    if (!outcome.ok) console.warn(`[adhd-ranch] ${op} failed`, outcome.kind, outcome.message);
+  }
+
   async function handleClearTask(index: number) {
     if (!selectedFocus) return;
-    try {
-      await focusWriter.deleteTask(selectedFocus.id, index);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("delete_task", await focusWriter.deleteTask(selectedFocus.id, index));
   }
 
   async function handleAddTask(text: string) {
     if (!selectedFocus) return;
-    try {
-      await focusWriter.appendTask(selectedFocus.id, text);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("append_task", await focusWriter.appendTask(selectedFocus.id, text));
   }
 
   async function handleRenameFocus(focusId: string, title: string) {
-    try {
-      await focusWriter.renameFocus(focusId, title);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("rename_focus", await focusWriter.renameFocus(focusId, title));
   }
 
   async function handleUpdateTask(focusId: string, index: number, text: string) {
-    try {
-      await focusWriter.updateTask(focusId, index, text);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("update_task", await focusWriter.updateTask(focusId, index, text));
   }
 
   async function handleToggleTask(focusId: string, index: number, done: boolean) {
-    try {
-      await focusWriter.toggleTask(focusId, index, done);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("toggle_task", await focusWriter.toggleTask(focusId, index, done));
   }
 
   async function handleDeleteFocus(focusId: string) {
-    try {
-      await focusWriter.deleteFocus(focusId);
-    } catch {
-      // focusWriter already logs the typed error
-    }
+    reportFailure("delete_focus", await focusWriter.deleteFocus(focusId));
   }
 
   return (

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,12 +10,15 @@ import type { Focus } from "../types/focus";
 import { PigDetail } from "./PigDetail";
 import { PigSprite } from "./PigSprite";
 
+export type ReportWriteFailure = (op: string, outcome: WriteOutcome) => void;
+
 export interface AppProps {
   readonly focusReader: PolledReader<readonly Focus[]>;
   readonly focusWriter: FocusWriter;
+  readonly onWriteFailure: ReportWriteFailure;
 }
 
-export function App({ focusReader, focusWriter }: AppProps) {
+export function App({ focusReader, focusWriter, onWriteFailure }: AppProps) {
   const focusState = usePolledReader(focusReader);
   const focuses = focusState.status === "ready" ? focusState.value : [];
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -27,34 +30,30 @@ export function App({ focusReader, focusWriter }: AppProps) {
   const selectedPig = pigs.find((p) => p.id === selectedId);
   const selectedFocus = focuses.find((f) => f.id === selectedId);
 
-  function reportFailure(op: string, outcome: WriteOutcome) {
-    if (!outcome.ok) console.warn(`[adhd-ranch] ${op} failed`, outcome.kind, outcome.message);
-  }
-
   async function handleClearTask(index: number) {
     if (!selectedFocus) return;
-    reportFailure("delete_task", await focusWriter.deleteTask(selectedFocus.id, index));
+    onWriteFailure("delete_task", await focusWriter.deleteTask(selectedFocus.id, index));
   }
 
   async function handleAddTask(text: string) {
     if (!selectedFocus) return;
-    reportFailure("append_task", await focusWriter.appendTask(selectedFocus.id, text));
+    onWriteFailure("append_task", await focusWriter.appendTask(selectedFocus.id, text));
   }
 
   async function handleRenameFocus(focusId: string, title: string) {
-    reportFailure("rename_focus", await focusWriter.renameFocus(focusId, title));
+    onWriteFailure("rename_focus", await focusWriter.renameFocus(focusId, title));
   }
 
   async function handleUpdateTask(focusId: string, index: number, text: string) {
-    reportFailure("update_task", await focusWriter.updateTask(focusId, index, text));
+    onWriteFailure("update_task", await focusWriter.updateTask(focusId, index, text));
   }
 
   async function handleToggleTask(focusId: string, index: number, done: boolean) {
-    reportFailure("toggle_task", await focusWriter.toggleTask(focusId, index, done));
+    onWriteFailure("toggle_task", await focusWriter.toggleTask(focusId, index, done));
   }
 
   async function handleDeleteFocus(focusId: string) {
-    reportFailure("delete_focus", await focusWriter.deleteFocus(focusId));
+    onWriteFailure("delete_focus", await focusWriter.deleteFocus(focusId));
   }
 
   return (

--- a/src/hooks/useNewFocusWindow.ts
+++ b/src/hooks/useNewFocusWindow.ts
@@ -47,16 +47,19 @@ export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState
     }
     setSubmitting(true);
     setError(null);
-    const outcome = await focusWriter.createFocus({
-      title: title.trim(),
-      description: description.trim(),
-    });
-    if (outcome.ok) {
-      await hideWindow();
-    } else {
-      setError(outcome.message);
+    try {
+      const outcome = await focusWriter.createFocus({
+        title: title.trim(),
+        description: description.trim(),
+      });
+      if (outcome.ok) {
+        await hideWindow();
+      } else {
+        setError(outcome.message);
+      }
+    } finally {
+      setSubmitting(false);
     }
-    setSubmitting(false);
   };
 
   const handleCancel = async () => {

--- a/src/hooks/useNewFocusWindow.ts
+++ b/src/hooks/useNewFocusWindow.ts
@@ -47,14 +47,16 @@ export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState
     }
     setSubmitting(true);
     setError(null);
-    try {
-      await focusWriter.createFocus({ title: title.trim(), description: description.trim() });
+    const outcome = await focusWriter.createFocus({
+      title: title.trim(),
+      description: description.trim(),
+    });
+    if (outcome.ok) {
       await hideWindow();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSubmitting(false);
+    } else {
+      setError(outcome.message);
     }
+    setSubmitting(false);
   };
 
   const handleCancel = async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createTauriFocusWriter } from "./api/focusWriter";
+import { type WriteOutcome, createTauriFocusWriter } from "./api/focusWriter";
 import { createTauriFocusReader } from "./api/tauriFocusReader";
 import { App } from "./components/App";
 import "./styles.css";
@@ -11,8 +11,12 @@ if (!rootEl) throw new Error("missing #root");
 const focusReader = createTauriFocusReader();
 const focusWriter = createTauriFocusWriter();
 
+function reportWriteFailure(op: string, outcome: WriteOutcome) {
+  if (!outcome.ok) console.warn(`[adhd-ranch] ${op} failed`, outcome.kind, outcome.message);
+}
+
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App focusReader={focusReader} focusWriter={focusWriter} />
+    <App focusReader={focusReader} focusWriter={focusWriter} onWriteFailure={reportWriteFailure} />
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Every `FocusWriter` method now returns a discriminated `WriteOutcome` (`{ ok: true }` or `{ ok: false; kind: "ipc" | "domain" | "not_found"; message }`)
- No rejection escapes the writer; `App.tsx` drops all `try/catch` and branches on `outcome.ok` via a `reportFailure` helper that `console.warn`s
- New `fixtureFocusWriter` with configurable failure injector for tests; `useNewFocusWindow` surfaces `outcome.message` via the existing `error` state

Closes issue 041. Hands off to issue 029 (`NotificationSource`) for the user-visible toast layer.

## Test plan

- [x] `task check` green (lint + typecheck + cargo tests + vitest)
- [x] Vitest: 4 tauriFocusWriter cases (ok / ipc / domain / not_found) + 2 fixtureFocusWriter cases
- [x] App.test.tsx noopFocusWriter updated to return `{ ok: true }`; 75/75 frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering success and varied failure cases for the writer implementations.

* **Refactor**
  * Writer operations now return structured success/failure outcomes instead of throwing, enabling consistent error handling.

* **New Features**
  * Centralized write-failure reporting hook and updated UI flows so create/add operations surface backend error messages to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->