### PR TITLE
[timer-picker-ui]: Preset picker in NewFocusWindow + PigDetail

### DIFF
--- a/crates/commands/src/focus.rs
+++ b/crates/commands/src/focus.rs
@@ -99,6 +99,16 @@ impl Commands {
         Ok(())
     }
 
+    pub fn start_timer(&self, focus_id: &str, preset: TimerPreset) -> Result<(), CommandError> {
+        let timer = FocusTimer {
+            duration_secs: preset.duration_secs(),
+            started_at: (self.clock_secs)(),
+            status: TimerStatus::Running,
+        };
+        self.store.update_timer(focus_id, &timer)?;
+        Ok(())
+    }
+
     pub fn caps(&self) -> Caps {
         self.settings.caps
     }
@@ -251,6 +261,38 @@ mod tests {
         commands.toggle_task(&created.id, 0, false).unwrap();
         let focuses = commands.list_focuses().unwrap();
         assert!(!focuses[0].tasks[0].done);
+    }
+
+    #[test]
+    fn start_timer_sets_running_timer_with_preset_duration() {
+        let started_at = 1_700_000_500_i64;
+        let (commands, _dir) = build_commands(started_at);
+        let created = commands
+            .create_focus(CreateFocusInput {
+                title: "No timer yet".into(),
+                description: String::new(),
+                timer_preset: None,
+            })
+            .unwrap();
+
+        commands
+            .start_timer(&created.id, TimerPreset::Four)
+            .unwrap();
+
+        let focuses = commands.list_focuses().unwrap();
+        let timer = focuses[0].timer.as_ref().expect("timer should be Some");
+        assert_eq!(timer.duration_secs, 240);
+        assert_eq!(timer.started_at, started_at);
+        assert_eq!(timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn start_timer_unknown_focus_returns_not_found() {
+        let (commands, _dir) = build_commands(0);
+        let err = commands
+            .start_timer("does-not-exist", TimerPreset::Two)
+            .unwrap_err();
+        assert!(matches!(err, CommandError::NotFound(_)));
     }
 
     #[test]

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -54,6 +54,7 @@ pub fn run() {
             ui_bridge::rename_focus,
             ui_bridge::update_task,
             ui_bridge::toggle_task,
+            ui_bridge::start_timer,
             ui_bridge::get_caps,
             ui_bridge::update_pig_rects,
             ui_bridge::set_pig_drag_active,

--- a/src-tauri/src/ui_bridge/mod.rs
+++ b/src-tauri/src/ui_bridge/mod.rs
@@ -5,7 +5,7 @@ use adhd_ranch_commands::{
     CommandError, Commands, CreateFocusInput, CreatedFocus, CreatedProposal, DecisionOutcome,
     ProposalEdit,
 };
-use adhd_ranch_domain::{Caps, Focus, Proposal, Settings};
+use adhd_ranch_domain::{Caps, Focus, Proposal, Settings, TimerPreset};
 use adhd_ranch_storage::write_settings;
 
 use tauri::{AppHandle, Emitter, Manager, State, Wry};
@@ -132,6 +132,19 @@ pub fn toggle_task(
         .toggle_task(&focus_id, index, done)
         .inspect(|_| log::info!("task {index} in {focus_id} toggled to {done}"))
         .inspect_err(|e| log::error!("toggle_task({focus_id:?}, {index}, {done}): {e}"))
+}
+
+#[tauri::command]
+pub fn start_timer(
+    focus_id: String,
+    preset: TimerPreset,
+    state: State<'_, CommandsState>,
+) -> Result<(), CommandError> {
+    state
+        .0
+        .start_timer(&focus_id, preset)
+        .inspect(|_| log::info!("timer started on {focus_id}"))
+        .inspect_err(|e| log::error!("start_timer({focus_id:?}): {e}"))
 }
 
 #[tauri::command]

--- a/src/api/fixtureFocusWriter.ts
+++ b/src/api/fixtureFocusWriter.ts
@@ -15,5 +15,6 @@ export function createFixtureFocusWriter(opts: FixtureFocusWriterOptions = {}): 
     deleteTask: result,
     updateTask: result,
     toggleTask: result,
+    startTimer: result,
   };
 }

--- a/src/api/focusWriter.test.ts
+++ b/src/api/focusWriter.test.ts
@@ -56,4 +56,29 @@ describe("tauriFocusWriter", () => {
 
     expect(outcome).toEqual({ ok: false, kind: "not_found", message: "focus missing: x" });
   });
+
+  it("startTimer forwards focusId + preset", async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+    const writer = createTauriFocusWriter();
+
+    const outcome = await writer.startTimer("focus-1", "Eight");
+
+    expect(outcome).toEqual({ ok: true });
+    expect(mockInvoke).toHaveBeenCalledWith("start_timer", {
+      focusId: "focus-1",
+      preset: "Eight",
+    });
+  });
+
+  it("startTimer forwards custom preset object", async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+    const writer = createTauriFocusWriter();
+
+    await writer.startTimer("focus-1", { Custom: 15 });
+
+    expect(mockInvoke).toHaveBeenCalledWith("start_timer", {
+      focusId: "focus-1",
+      preset: { Custom: 15 },
+    });
+  });
 });

--- a/src/api/focusWriter.ts
+++ b/src/api/focusWriter.ts
@@ -19,6 +19,7 @@ export interface FocusWriter {
   deleteTask(focusId: string, index: number): Promise<WriteOutcome>;
   updateTask(focusId: string, index: number, text: string): Promise<WriteOutcome>;
   toggleTask(focusId: string, index: number, done: boolean): Promise<WriteOutcome>;
+  startTimer(focusId: string, preset: TimerPreset): Promise<WriteOutcome>;
 }
 
 function toFailure(e: unknown): WriteOutcome {
@@ -66,6 +67,9 @@ export function createTauriFocusWriter(): FocusWriter {
     },
     toggleTask(focusId, index, done) {
       return runInvoke("toggle_task", { focusId, index, done });
+    },
+    startTimer(focusId, preset) {
+      return runInvoke("start_timer", { focusId, preset });
     },
   };
 }

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -54,6 +54,7 @@ function noopFocusWriter(): FocusWriter {
     deleteTask: vi.fn().mockResolvedValue(ok),
     updateTask: vi.fn().mockResolvedValue(ok),
     toggleTask: vi.fn().mockResolvedValue(ok),
+    startTimer: vi.fn().mockResolvedValue(ok),
   };
 }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,6 +7,7 @@ import { usePigMovement } from "../hooks/usePigMovement";
 import { usePolledReader } from "../hooks/usePolledReader";
 import { useViewport } from "../hooks/useViewport";
 import type { Focus } from "../types/focus";
+import type { TimerPreset } from "../types/timer";
 import { PigDetail } from "./PigDetail";
 import { PigSprite } from "./PigSprite";
 
@@ -54,6 +55,10 @@ export function App({ focusReader, focusWriter, onWriteFailure }: AppProps) {
 
   async function handleDeleteFocus(focusId: string) {
     onWriteFailure("delete_focus", await focusWriter.deleteFocus(focusId));
+  }
+
+  async function handleStartTimer(focusId: string, preset: TimerPreset) {
+    onWriteFailure("start_timer", await focusWriter.startTimer(focusId, preset));
   }
 
   return (
@@ -107,6 +112,7 @@ export function App({ focusReader, focusWriter, onWriteFailure }: AppProps) {
           onUpdateTask={handleUpdateTask}
           onToggleTask={handleToggleTask}
           onDeleteFocus={handleDeleteFocus}
+          onStartTimer={handleStartTimer}
         />
       )}
     </div>

--- a/src/components/NewFocusWindow.tsx
+++ b/src/components/NewFocusWindow.tsx
@@ -1,10 +1,16 @@
+import { type PresetSelection, TimerPresetPicker } from "./TimerPresetPicker";
+
 export interface NewFocusWindowProps {
   readonly title: string;
   readonly description: string;
+  readonly timerSelection: PresetSelection;
+  readonly customMinutes: number;
   readonly submitting: boolean;
   readonly error: string | null;
   readonly onTitleChange: (v: string) => void;
   readonly onDescriptionChange: (v: string) => void;
+  readonly onTimerSelectionChange: (v: PresetSelection) => void;
+  readonly onCustomMinutesChange: (v: number) => void;
   readonly onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   readonly onCancel: () => void;
 }
@@ -12,10 +18,14 @@ export interface NewFocusWindowProps {
 export function NewFocusWindow({
   title,
   description,
+  timerSelection,
+  customMinutes,
   submitting,
   error,
   onTitleChange,
   onDescriptionChange,
+  onTimerSelectionChange,
+  onCustomMinutesChange,
   onSubmit,
   onCancel,
 }: NewFocusWindowProps) {
@@ -38,6 +48,13 @@ export function NewFocusWindow({
         value={description}
         onChange={(e) => onDescriptionChange(e.target.value)}
         disabled={submitting}
+      />
+      <TimerPresetPicker
+        selection={timerSelection}
+        customMinutes={customMinutes}
+        disabled={submitting}
+        onSelectionChange={onTimerSelectionChange}
+        onCustomMinutesChange={onCustomMinutesChange}
       />
       <div className="new-focus-actions">
         <button type="submit" disabled={submitting}>

--- a/src/components/NewFocusWindow.tsx
+++ b/src/components/NewFocusWindow.tsx
@@ -1,4 +1,5 @@
-import { type PresetSelection, TimerPresetPicker } from "./TimerPresetPicker";
+import type { PresetSelection } from "../lib/timerPreset";
+import { TimerPresetPicker } from "./TimerPresetPicker";
 
 export interface NewFocusWindowProps {
   readonly title: string;

--- a/src/components/PigDetail.test.tsx
+++ b/src/components/PigDetail.test.tsx
@@ -27,6 +27,7 @@ function renderDetail(overrides?: Partial<React.ComponentProps<typeof PigDetail>
     onUpdateTask: vi.fn(),
     onToggleTask: vi.fn(),
     onDeleteFocus: vi.fn(),
+    onStartTimer: vi.fn(),
     ...overrides,
   };
   render(<PigDetail {...props} />);
@@ -153,5 +154,51 @@ describe("PigDetail delete focus", () => {
     await userEvent.click(screen.getByLabelText("delete focus Ship it"));
     expect(onDeleteFocus).toHaveBeenCalledWith("pig-a");
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("PigDetail timer picker", () => {
+  it("renders Start button + preset select", () => {
+    renderDetail();
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(screen.getByTestId("timer-preset-select")).toBeInTheDocument();
+  });
+
+  it("Start with named preset calls onStartTimer with preset literal", async () => {
+    const { onStartTimer } = renderDetail();
+    await userEvent.selectOptions(screen.getByTestId("timer-preset-select"), "ThirtyTwo");
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+    expect(onStartTimer).toHaveBeenCalledWith("pig-a", "ThirtyTwo");
+  });
+
+  it("Start with custom preset wraps minutes", async () => {
+    const { onStartTimer } = renderDetail();
+    await userEvent.selectOptions(screen.getByTestId("timer-preset-select"), "custom");
+    const input = screen.getByTestId("custom-timer-input");
+    await userEvent.clear(input);
+    await userEvent.type(input, "25");
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+    expect(onStartTimer).toHaveBeenCalledWith("pig-a", { Custom: 25 });
+  });
+
+  it("rejects custom < 1 minute", async () => {
+    const { onStartTimer } = renderDetail();
+    await userEvent.selectOptions(screen.getByTestId("timer-preset-select"), "custom");
+    const input = screen.getByTestId("custom-timer-input");
+    await userEvent.clear(input);
+    await userEvent.type(input, "0");
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+    expect(onStartTimer).not.toHaveBeenCalled();
+    expect(screen.getByText(/at least 1 minute/i)).toBeInTheDocument();
+  });
+
+  it("button reads Restart when timer is Running", () => {
+    renderDetail({
+      focus: {
+        ...baseFocus,
+        timer: { duration_secs: 600, started_at: 0, status: "Running" },
+      },
+    });
+    expect(screen.getByRole("button", { name: "Restart" })).toBeInTheDocument();
   });
 });

--- a/src/components/PigDetail.test.tsx
+++ b/src/components/PigDetail.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { Focus } from "../types/focus";
 import { PigDetail } from "./PigDetail";
@@ -200,5 +201,42 @@ describe("PigDetail timer picker", () => {
       },
     });
     expect(screen.getByRole("button", { name: "Restart" })).toBeInTheDocument();
+  });
+
+  it("resets picker state when focus changes", async () => {
+    function Harness() {
+      const [focusId, setFocusId] = useState("pig-a");
+      return (
+        <>
+          <button type="button" data-testid="swap" onClick={() => setFocusId("pig-b")}>
+            swap
+          </button>
+          <PigDetail
+            focus={{ ...baseFocus, id: focusId }}
+            pigX={100}
+            pigY={100}
+            viewportW={1920}
+            viewportH={1080}
+            confirmDelete={true}
+            onClose={vi.fn()}
+            onClearTask={vi.fn()}
+            onAddTask={vi.fn()}
+            onRenameFocus={vi.fn()}
+            onUpdateTask={vi.fn()}
+            onToggleTask={vi.fn()}
+            onDeleteFocus={vi.fn()}
+            onStartTimer={vi.fn()}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    await userEvent.selectOptions(screen.getByTestId("timer-preset-select"), "Sixteen");
+    expect(screen.getByTestId("timer-preset-select")).toHaveValue("Sixteen");
+
+    await userEvent.click(screen.getByTestId("swap"));
+
+    expect(screen.getByTestId("timer-preset-select")).toHaveValue("Eight");
   });
 });

--- a/src/components/PigDetail.tsx
+++ b/src/components/PigDetail.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useState } from "react";
 import { PIG_SIZE } from "../hooks/usePigMovement";
+import { type PresetSelection, isCustomValid, resolvePreset } from "../lib/timerPreset";
 import type { Focus } from "../types/focus";
 import type { TimerPreset } from "../types/timer";
-import {
-  type PresetSelection,
-  TimerPresetPicker,
-  isCustomValid,
-  resolvePreset,
-} from "./TimerPresetPicker";
+import { TimerPresetPicker } from "./TimerPresetPicker";
 
 export interface PigDetailProps {
   readonly focus: Focus;
@@ -68,6 +64,13 @@ export function PigDetail({
     setTitleDraft(focus.title);
     setTitleError(false);
   }, [focus.title]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run when switching to a different focus so picker state doesn't leak.
+  useEffect(() => {
+    setTimerSelection("Eight");
+    setCustomMinutes(10);
+    setTimerError(null);
+  }, [focus.id]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/PigDetail.tsx
+++ b/src/components/PigDetail.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { PIG_SIZE } from "../hooks/usePigMovement";
 import type { Focus } from "../types/focus";
+import type { TimerPreset } from "../types/timer";
+import {
+  type PresetSelection,
+  TimerPresetPicker,
+  isCustomValid,
+  resolvePreset,
+} from "./TimerPresetPicker";
 
 export interface PigDetailProps {
   readonly focus: Focus;
@@ -16,6 +23,7 @@ export interface PigDetailProps {
   readonly onUpdateTask: (focusId: string, index: number, text: string) => void;
   readonly onToggleTask: (focusId: string, index: number, done: boolean) => void;
   readonly onDeleteFocus: (focusId: string) => void;
+  readonly onStartTimer: (focusId: string, preset: TimerPreset) => void;
 }
 
 const CARD_W = 340;
@@ -35,11 +43,26 @@ export function PigDetail({
   onUpdateTask,
   onToggleTask,
   onDeleteFocus,
+  onStartTimer,
 }: PigDetailProps) {
   const [taskInput, setTaskInput] = useState("");
   const [titleDraft, setTitleDraft] = useState(focus.title);
   const [titleError, setTitleError] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [timerSelection, setTimerSelection] = useState<PresetSelection>("Eight");
+  const [customMinutes, setCustomMinutes] = useState(10);
+  const [timerError, setTimerError] = useState<string | null>(null);
+
+  function handleStartTimer() {
+    if (timerSelection === "custom" && !isCustomValid(customMinutes)) {
+      setTimerError("custom timer must be at least 1 minute");
+      return;
+    }
+    const preset = resolvePreset(timerSelection, customMinutes);
+    if (preset === null) return;
+    setTimerError(null);
+    onStartTimer(focus.id, preset);
+  }
 
   useEffect(() => {
     setTitleDraft(focus.title);
@@ -184,6 +207,29 @@ export function PigDetail({
             }
           }}
         />
+        <div className="pig-detail-timer">
+          <TimerPresetPicker
+            selection={timerSelection}
+            customMinutes={customMinutes}
+            allowNone={false}
+            onSelectionChange={(v) => {
+              setTimerSelection(v);
+              if (timerError) setTimerError(null);
+            }}
+            onCustomMinutesChange={(v) => {
+              setCustomMinutes(v);
+              if (timerError) setTimerError(null);
+            }}
+          />
+          <button type="button" className="pig-detail-timer-start" onClick={handleStartTimer}>
+            {focus.timer && focus.timer.status === "Running" ? "Restart" : "Start"}
+          </button>
+          {timerError && (
+            <p className="pig-detail-timer-error" role="alert">
+              {timerError}
+            </p>
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/components/TimerPresetPicker.test.tsx
+++ b/src/components/TimerPresetPicker.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type PresetSelection,
+  TimerPresetPicker,
+  isCustomValid,
+  resolvePreset,
+} from "./TimerPresetPicker";
+
+describe("resolvePreset", () => {
+  it("returns null for none", () => {
+    expect(resolvePreset("none", 10)).toBeNull();
+  });
+
+  it("returns named presets verbatim", () => {
+    expect(resolvePreset("Eight", 10)).toBe("Eight");
+    expect(resolvePreset("ThirtyTwo", 10)).toBe("ThirtyTwo");
+  });
+
+  it("wraps custom minutes", () => {
+    expect(resolvePreset("custom", 15)).toEqual({ Custom: 15 });
+  });
+});
+
+describe("isCustomValid", () => {
+  it("rejects sub-minute values", () => {
+    expect(isCustomValid(0)).toBe(false);
+    expect(isCustomValid(-1)).toBe(false);
+  });
+
+  it("rejects non-integer or non-finite", () => {
+    expect(isCustomValid(1.5)).toBe(false);
+    expect(isCustomValid(Number.NaN)).toBe(false);
+    expect(isCustomValid(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("accepts integers >= 1", () => {
+    expect(isCustomValid(1)).toBe(true);
+    expect(isCustomValid(120)).toBe(true);
+  });
+});
+
+describe("TimerPresetPicker", () => {
+  it("renders preset options including No timer when allowNone", () => {
+    render(
+      <TimerPresetPicker
+        selection="none"
+        customMinutes={10}
+        onSelectionChange={vi.fn()}
+        onCustomMinutesChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("option", { name: "No timer" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Custom" })).toBeInTheDocument();
+  });
+
+  it("hides No timer when allowNone is false", () => {
+    render(
+      <TimerPresetPicker
+        selection="Two"
+        customMinutes={10}
+        allowNone={false}
+        onSelectionChange={vi.fn()}
+        onCustomMinutesChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("option", { name: "No timer" })).not.toBeInTheDocument();
+  });
+
+  it("reveals custom input when custom selected", async () => {
+    const onSelectionChange = vi.fn();
+    const { rerender } = render(
+      <TimerPresetPicker
+        selection="none"
+        customMinutes={10}
+        onSelectionChange={onSelectionChange}
+        onCustomMinutesChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("custom-timer-input")).not.toBeInTheDocument();
+
+    await userEvent.selectOptions(screen.getByTestId("timer-preset-select"), "custom");
+    expect(onSelectionChange).toHaveBeenCalledWith("custom" satisfies PresetSelection);
+
+    rerender(
+      <TimerPresetPicker
+        selection="custom"
+        customMinutes={10}
+        onSelectionChange={onSelectionChange}
+        onCustomMinutesChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("custom-timer-input")).toBeInTheDocument();
+  });
+});

--- a/src/components/TimerPresetPicker.test.tsx
+++ b/src/components/TimerPresetPicker.test.tsx
@@ -1,45 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import {
-  type PresetSelection,
-  TimerPresetPicker,
-  isCustomValid,
-  resolvePreset,
-} from "./TimerPresetPicker";
-
-describe("resolvePreset", () => {
-  it("returns null for none", () => {
-    expect(resolvePreset("none", 10)).toBeNull();
-  });
-
-  it("returns named presets verbatim", () => {
-    expect(resolvePreset("Eight", 10)).toBe("Eight");
-    expect(resolvePreset("ThirtyTwo", 10)).toBe("ThirtyTwo");
-  });
-
-  it("wraps custom minutes", () => {
-    expect(resolvePreset("custom", 15)).toEqual({ Custom: 15 });
-  });
-});
-
-describe("isCustomValid", () => {
-  it("rejects sub-minute values", () => {
-    expect(isCustomValid(0)).toBe(false);
-    expect(isCustomValid(-1)).toBe(false);
-  });
-
-  it("rejects non-integer or non-finite", () => {
-    expect(isCustomValid(1.5)).toBe(false);
-    expect(isCustomValid(Number.NaN)).toBe(false);
-    expect(isCustomValid(Number.POSITIVE_INFINITY)).toBe(false);
-  });
-
-  it("accepts integers >= 1", () => {
-    expect(isCustomValid(1)).toBe(true);
-    expect(isCustomValid(120)).toBe(true);
-  });
-});
+import type { PresetSelection } from "../lib/timerPreset";
+import { TimerPresetPicker } from "./TimerPresetPicker";
 
 describe("TimerPresetPicker", () => {
   it("renders preset options including No timer when allowNone", () => {

--- a/src/components/TimerPresetPicker.tsx
+++ b/src/components/TimerPresetPicker.tsx
@@ -1,39 +1,4 @@
-import type { TimerPreset } from "../types/timer";
-
-export type PresetSelection =
-  | "none"
-  | "Two"
-  | "Four"
-  | "Eight"
-  | "Sixteen"
-  | "ThirtyTwo"
-  | "custom";
-
-export function resolvePreset(
-  selection: PresetSelection,
-  customMinutes: number,
-): TimerPreset | null {
-  switch (selection) {
-    case "Two":
-      return "Two";
-    case "Four":
-      return "Four";
-    case "Eight":
-      return "Eight";
-    case "Sixteen":
-      return "Sixteen";
-    case "ThirtyTwo":
-      return "ThirtyTwo";
-    case "custom":
-      return { Custom: customMinutes };
-    default:
-      return null;
-  }
-}
-
-export function isCustomValid(customMinutes: number): boolean {
-  return Number.isFinite(customMinutes) && Number.isInteger(customMinutes) && customMinutes >= 1;
-}
+import type { PresetSelection } from "../lib/timerPreset";
 
 export interface TimerPresetPickerProps {
   readonly selection: PresetSelection;

--- a/src/components/TimerPresetPicker.tsx
+++ b/src/components/TimerPresetPicker.tsx
@@ -1,0 +1,85 @@
+import type { TimerPreset } from "../types/timer";
+
+export type PresetSelection =
+  | "none"
+  | "Two"
+  | "Four"
+  | "Eight"
+  | "Sixteen"
+  | "ThirtyTwo"
+  | "custom";
+
+export function resolvePreset(
+  selection: PresetSelection,
+  customMinutes: number,
+): TimerPreset | null {
+  switch (selection) {
+    case "Two":
+      return "Two";
+    case "Four":
+      return "Four";
+    case "Eight":
+      return "Eight";
+    case "Sixteen":
+      return "Sixteen";
+    case "ThirtyTwo":
+      return "ThirtyTwo";
+    case "custom":
+      return { Custom: customMinutes };
+    default:
+      return null;
+  }
+}
+
+export function isCustomValid(customMinutes: number): boolean {
+  return Number.isFinite(customMinutes) && Number.isInteger(customMinutes) && customMinutes >= 1;
+}
+
+export interface TimerPresetPickerProps {
+  readonly selection: PresetSelection;
+  readonly customMinutes: number;
+  readonly disabled?: boolean;
+  readonly allowNone?: boolean;
+  readonly onSelectionChange: (v: PresetSelection) => void;
+  readonly onCustomMinutesChange: (v: number) => void;
+}
+
+export function TimerPresetPicker({
+  selection,
+  customMinutes,
+  disabled,
+  allowNone = true,
+  onSelectionChange,
+  onCustomMinutesChange,
+}: TimerPresetPickerProps) {
+  return (
+    <>
+      <select
+        aria-label="timer preset"
+        data-testid="timer-preset-select"
+        value={selection}
+        onChange={(e) => onSelectionChange(e.target.value as PresetSelection)}
+        disabled={disabled}
+      >
+        {allowNone && <option value="none">No timer</option>}
+        <option value="Two">2m</option>
+        <option value="Four">4m</option>
+        <option value="Eight">8m</option>
+        <option value="Sixteen">16m</option>
+        <option value="ThirtyTwo">32m</option>
+        <option value="custom">Custom</option>
+      </select>
+      {selection === "custom" && (
+        <input
+          type="number"
+          aria-label="custom timer minutes"
+          data-testid="custom-timer-input"
+          min={1}
+          value={customMinutes}
+          onChange={(e) => onCustomMinutesChange(Number(e.target.value))}
+          disabled={disabled}
+        />
+      )}
+    </>
+  );
+}

--- a/src/hooks/useNewFocusWindow.ts
+++ b/src/hooks/useNewFocusWindow.ts
@@ -1,11 +1,7 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
 import type { FocusWriter } from "../api/focusWriter";
-import {
-  type PresetSelection,
-  isCustomValid,
-  resolvePreset,
-} from "../components/TimerPresetPicker";
+import { type PresetSelection, isCustomValid, resolvePreset } from "../lib/timerPreset";
 
 export interface NewFocusWindowState {
   readonly title: string;

--- a/src/hooks/useNewFocusWindow.ts
+++ b/src/hooks/useNewFocusWindow.ts
@@ -1,14 +1,23 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
 import type { FocusWriter } from "../api/focusWriter";
+import {
+  type PresetSelection,
+  isCustomValid,
+  resolvePreset,
+} from "../components/TimerPresetPicker";
 
 export interface NewFocusWindowState {
   readonly title: string;
   readonly description: string;
+  readonly timerSelection: PresetSelection;
+  readonly customMinutes: number;
   readonly submitting: boolean;
   readonly error: string | null;
   readonly setTitle: (v: string) => void;
   readonly setDescription: (v: string) => void;
+  readonly setTimerSelection: (v: PresetSelection) => void;
+  readonly setCustomMinutes: (v: number) => void;
   readonly handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
   readonly handleCancel: () => Promise<void>;
 }
@@ -16,13 +25,21 @@ export interface NewFocusWindowState {
 export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [timerSelection, setTimerSelection] = useState<PresetSelection>("none");
+  const [customMinutes, setCustomMinutes] = useState(10);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const hideWindow = async () => {
+  const resetForm = () => {
     setTitle("");
     setDescription("");
+    setTimerSelection("none");
+    setCustomMinutes(10);
     setError(null);
+  };
+
+  const hideWindow = async () => {
+    resetForm();
     await getCurrentWindow().hide();
   };
 
@@ -31,6 +48,8 @@ export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState
       if (e.key === "Escape") {
         setTitle("");
         setDescription("");
+        setTimerSelection("none");
+        setCustomMinutes(10);
         setError(null);
         void getCurrentWindow().hide();
       }
@@ -45,12 +64,17 @@ export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState
       setError("title is required");
       return;
     }
+    if (timerSelection === "custom" && !isCustomValid(customMinutes)) {
+      setError("custom timer must be at least 1 minute");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
       const outcome = await focusWriter.createFocus({
         title: title.trim(),
         description: description.trim(),
+        timer_preset: resolvePreset(timerSelection, customMinutes),
       });
       if (outcome.ok) {
         await hideWindow();
@@ -69,10 +93,14 @@ export function useNewFocusWindow(focusWriter: FocusWriter): NewFocusWindowState
   return {
     title,
     description,
+    timerSelection,
+    customMinutes,
     submitting,
     error,
     setTitle,
     setDescription,
+    setTimerSelection,
+    setCustomMinutes,
     handleSubmit,
     handleCancel,
   };

--- a/src/lib/timerPreset.test.ts
+++ b/src/lib/timerPreset.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isCustomValid, resolvePreset } from "./timerPreset";
+
+describe("resolvePreset", () => {
+  it("returns null for none", () => {
+    expect(resolvePreset("none", 10)).toBeNull();
+  });
+
+  it("returns named presets verbatim", () => {
+    expect(resolvePreset("Eight", 10)).toBe("Eight");
+    expect(resolvePreset("ThirtyTwo", 10)).toBe("ThirtyTwo");
+  });
+
+  it("wraps custom minutes", () => {
+    expect(resolvePreset("custom", 15)).toEqual({ Custom: 15 });
+  });
+});
+
+describe("isCustomValid", () => {
+  it("rejects sub-minute values", () => {
+    expect(isCustomValid(0)).toBe(false);
+    expect(isCustomValid(-1)).toBe(false);
+  });
+
+  it("rejects non-integer or non-finite", () => {
+    expect(isCustomValid(1.5)).toBe(false);
+    expect(isCustomValid(Number.NaN)).toBe(false);
+    expect(isCustomValid(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("accepts integers >= 1", () => {
+    expect(isCustomValid(1)).toBe(true);
+    expect(isCustomValid(120)).toBe(true);
+  });
+});

--- a/src/lib/timerPreset.ts
+++ b/src/lib/timerPreset.ts
@@ -1,0 +1,36 @@
+import type { TimerPreset } from "../types/timer";
+
+export type PresetSelection =
+  | "none"
+  | "Two"
+  | "Four"
+  | "Eight"
+  | "Sixteen"
+  | "ThirtyTwo"
+  | "custom";
+
+export function resolvePreset(
+  selection: PresetSelection,
+  customMinutes: number,
+): TimerPreset | null {
+  switch (selection) {
+    case "Two":
+      return "Two";
+    case "Four":
+      return "Four";
+    case "Eight":
+      return "Eight";
+    case "Sixteen":
+      return "Sixteen";
+    case "ThirtyTwo":
+      return "ThirtyTwo";
+    case "custom":
+      return { Custom: customMinutes };
+    default:
+      return null;
+  }
+}
+
+export function isCustomValid(customMinutes: number): boolean {
+  return Number.isFinite(customMinutes) && Number.isInteger(customMinutes) && customMinutes >= 1;
+}

--- a/src/new-focus.tsx
+++ b/src/new-focus.tsx
@@ -11,10 +11,14 @@ function NewFocusApp() {
   const {
     title,
     description,
+    timerSelection,
+    customMinutes,
     submitting,
     error,
     setTitle,
     setDescription,
+    setTimerSelection,
+    setCustomMinutes,
     handleSubmit,
     handleCancel,
   } = useNewFocusWindow(focusWriter);
@@ -23,10 +27,14 @@ function NewFocusApp() {
     <NewFocusWindow
       title={title}
       description={description}
+      timerSelection={timerSelection}
+      customMinutes={customMinutes}
       submitting={submitting}
       error={error}
       onTitleChange={setTitle}
       onDescriptionChange={setDescription}
+      onTimerSelectionChange={setTimerSelection}
+      onCustomMinutesChange={setCustomMinutes}
       onSubmit={handleSubmit}
       onCancel={() => void handleCancel()}
     />


### PR DESCRIPTION
## Summary

Replaces #54 (auto-closed when its base branch was deleted after #53 merged).

Adds the two surfaces where users actually set a timer:

- Dedicated Tauri **new-focus window** now exposes a preset dropdown (2/4/8/16/32m + custom) and submits the resolved preset to `create_focus`.
- **PigDetail** popover gains the same picker plus a Start/Restart button that fires a new `start_timer` command against an existing focus. Button label flips to "Restart" when `focus.timer.status === "Running"` to flag the overwrite.

Shared bits:
- `TimerPresetPicker` component extracted from the orphaned `NewFocusForm`. Orphan left in place per CLAUDE.md scope rule.
- `resolvePreset` / `isCustomValid` pure helpers; rejects custom < 1 minute.

Backend:
- `Commands::start_timer(focus_id, preset)` builds a Running `FocusTimer` (`started_at = clock_secs`, duration from preset) and calls `store.update_timer`.
- `ui_bridge::start_timer` registered; `FocusWriter.startTimer` follows the existing `WriteOutcome` pattern. Fixture + `App.test.tsx` mock updated.

## Test plan

- [x] `task check` green (lint + typecheck + cargo tests + vitest)
- [x] Backend: 2 new `start_timer` tests (preset-duration mapping, not-found)
- [x] Frontend: 9 `TimerPresetPicker` tests + 2 `FocusWriter.startTimer` tests + 4 `PigDetail` timer-picker tests
- [ ] Manual: open new-focus window, pick 2m, confirm timer fires via the #53 expiry loop
- [ ] Manual: click pig, pick custom 1m, confirm Start persists timer.json and expiry fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start/Restart timers for focus sessions with named presets (2,4,8,16,32) or custom minutes; Start button reflects running state.
  * Timer selection added to new-focus flow and focus details via a preset picker UI.

* **Bug Fixes / Validation**
  * Custom-minute input validated (must be integer ≥1) with inline error messaging.

* **Tests**
  * Extensive unit and UI tests covering preset resolution, picker behavior, start timer flows, and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->