### PR TITLE
[architecture-backlog]: Proposal lifecycle ADR and backlog issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - uses: arduino/setup-task@v2
         with:

--- a/docs/adr/0003-storage-transaction-seam-for-proposal-lifecycle.md
+++ b/docs/adr/0003-storage-transaction-seam-for-proposal-lifecycle.md
@@ -1,0 +1,95 @@
+# ADR-0003: Use a storage transaction seam for proposal lifecycle writes
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Closes:** issue 043 (`proposal-lifecycle-atomicity-design`)
+
+## Context
+
+`ProposalLifecycle::accept` currently performs three sequential writes:
+
+1. Apply the Proposal effect (`append_task`, `create_focus`, or no-op discard)
+2. Append a Decision to `decisions.jsonl`
+3. Remove the Proposal from `proposals.jsonl`
+
+The current interface returns `Result<DecisionOutcome>`, but the underlying writes are not atomic. If the process dies or a write fails after the Focus/Task mutation, the app can observe a partially accepted Proposal. Retrying can also duplicate the Decision append before the Proposal removal succeeds.
+
+Issue 043 considered two shapes:
+
+- `LifecycleCommit`: one value type for Proposal acceptance only
+- `FocusStore::transaction(|tx| ...)`: a general transaction seam for storage workflows
+
+The product is expected to add more multi-write workflows: `merge_focus`, `complete_task`, future Proposal kinds, and possibly settings or migration flows. This makes a one-off Proposal commit too narrow.
+
+## Decision
+
+Introduce a general storage transaction seam.
+
+The exact Rust names may shift during implementation, but the intended interface is:
+
+```rust
+trait StorageTransaction {
+    fn append_task(&mut self, focus_id: &str, text: &str) -> Result<(), StorageError>;
+    fn create_focus(
+        &mut self,
+        new_focus: &NewFocus,
+        id: &str,
+        created_at: &str,
+        timer: Option<FocusTimer>,
+    ) -> Result<String, StorageError>;
+    fn append_decision(&mut self, decision: &Decision) -> Result<(), StorageError>;
+    fn remove_proposal(&mut self, id: &ProposalId) -> Result<bool, StorageError>;
+}
+
+trait TransactionalStore {
+    fn transaction<R>(
+        &self,
+        f: impl FnOnce(&mut dyn StorageTransaction) -> Result<R, StorageError>,
+    ) -> Result<R, StorageError>;
+}
+```
+
+`ProposalLifecycle::accept` will build the edited Proposal and Decision, then run all storage effects inside one transaction. `ProposalLifecycle` owns Proposal rules; storage owns commit ordering, rollback, and recovery.
+
+The storage implementation should start pragmatic: file-based transaction staging under the app data root, using the existing atomic tmpfile + rename primitives where possible. It does not need a database. The transaction must be tested with injected failures between Focus/Task mutation, Decision append, and Proposal removal.
+
+## Why not `LifecycleCommit`
+
+`LifecycleCommit` is attractive for issue 043 alone: it is smaller and maps directly to Proposal acceptance.
+
+We are not choosing it because the seam would be too specific. As soon as `merge_focus` or `complete_task` arrives, either `LifecycleCommit` becomes a generic transaction language under another name, or a second transaction mechanism appears beside it. That would lower locality: future consistency bugs would require checking which workflow uses which commit shape.
+
+## Failure-mode coverage
+
+The transaction implementation must define recovery behavior for:
+
+- Failure before commit starts: no visible mutation.
+- Failure after staging but before final commit marker: old state remains authoritative or recovery rolls staged files forward deterministically.
+- Failure after the Focus/Task write but before Decision append: no accepted Proposal should be visible without its Decision.
+- Failure after Decision append but before Proposal removal: retry must not append a duplicate Decision.
+
+The follow-up implementation issue should choose the concrete marker/staging protocol. The invariant is more important than the exact file layout: after recovery, Proposal acceptance is visible as all three effects or none.
+
+## Test surface
+
+The implementation needs a failure-injection adapter or hook at each write step:
+
+- after Focus/Task mutation staging
+- after Decision append staging
+- after Proposal removal staging
+- before and after final commit marker
+
+Tests should run against temp dirs and assert on actual files, not only in-memory mocks.
+
+## Cost
+
+This is heavier than a Proposal-only commit. It introduces a new storage module, shared error type, and transaction staging tests.
+
+That cost is justified because the app is expected to gain more multi-write workflows. The interface buys leverage by concentrating atomicity, recovery, and write-ordering knowledge in one module instead of every workflow.
+
+## Consequences
+
+- Issue 043 is closed as a design decision.
+- A follow-up AFK issue implements the storage transaction seam and migrates `ProposalLifecycle::accept`.
+- Future architecture reviews should not re-suggest `LifecycleCommit` unless the planned multi-write workflows are cancelled.
+- `FocusStore`, `ProposalQueue`, and `DecisionLog` remain useful read/write adapters, but atomic cross-file workflows should go through the transaction seam.

--- a/issues/046-timer-expiry-service-extraction.md
+++ b/issues/046-timer-expiry-service-extraction.md
@@ -38,6 +38,10 @@ impl TimerExpiryService {
 
 CodeRabbit flagged this on PR #53 (https://github.com/killallgit/adhd-ranch/pull/53). Deferred to keep that PR scoped to issue 029.
 
+## Completion promise
+
+Timer expiry coordination is tested through one workflow module; `app/timer_expiry.rs` only wires dependencies and runs the interval loop.
+
 ## Acceptance criteria
 
 - [ ] `TimerExpiryService` exists in `crates/commands` (or a new dedicated crate); takes a `TimerExpiryNotifier` trait + `FocusStore` + clock + notification-settings provider via constructor injection.
@@ -49,6 +53,10 @@ CodeRabbit flagged this on PR #53 (https://github.com/killallgit/adhd-ranch/pull
 ## Blocked by
 
 - 029 (timer-expiry interface) — done
+
+## User stories addressed
+
+- "When a FocusTimer expires, the app updates storage, emits the UI event, and sends the configured notification through one testable workflow instead of inline Tauri code."
 
 ## Hands off to
 

--- a/issues/047-storage-transaction-seam.md
+++ b/issues/047-storage-transaction-seam.md
@@ -1,0 +1,71 @@
+# 047 — Storage transaction seam for Proposal lifecycle
+
+## Parent PRD
+
+PRD.md §FR5 (HTTP API), §FR8 (Audit log), and §Out of scope / v1.3+ (`/checkpoint` proposal flow) + [ADR-0003](../docs/adr/0003-storage-transaction-seam-for-proposal-lifecycle.md)
+
+## What to build
+
+Implement the general storage transaction seam chosen in ADR-0003 and move `ProposalLifecycle::accept` onto it.
+
+Today `ProposalLifecycle::accept` performs separate writes: apply the Proposal effect, append a Decision, then remove the Proposal. This must become one transaction so a crash or injected failure cannot leave a partially accepted Proposal.
+
+### Target shape
+
+Create a storage transaction module in `crates/storage` with a small interface for the write effects Proposal acceptance needs now:
+
+```rust
+trait StorageTransaction {
+    fn append_task(&mut self, focus_id: &str, text: &str) -> Result<(), StorageError>;
+    fn create_focus(
+        &mut self,
+        new_focus: &NewFocus,
+        id: &str,
+        created_at: &str,
+        timer: Option<FocusTimer>,
+    ) -> Result<String, StorageError>;
+    fn append_decision(&mut self, decision: &Decision) -> Result<(), StorageError>;
+    fn remove_proposal(&mut self, id: &ProposalId) -> Result<bool, StorageError>;
+}
+
+trait TransactionalStore {
+    fn transaction<R>(
+        &self,
+        f: impl FnOnce(&mut dyn StorageTransaction) -> Result<R, StorageError>,
+    ) -> Result<R, StorageError>;
+}
+```
+
+Concrete names may change, but the seam must be general enough for future multi-write workflows such as `merge_focus` and `complete_task`.
+
+### Implementation notes
+
+- Keep the concrete implementation file-based; do not introduce a database.
+- Use temp dirs/files and atomic rename primitives.
+- Define recovery behavior for an interrupted transaction.
+- Add failure injection at each meaningful write step so tests can prove all-or-none behavior.
+- `ProposalLifecycle::accept` should construct the edited Proposal and Decision, then call the transaction seam. It should not manually coordinate cross-file ordering anymore.
+- `reject` may remain simple unless sharing the transaction makes the implementation clearer; either way, explain the choice in code or tests.
+
+## Completion promise
+
+Accepting a Proposal is atomic across Focus/Task mutation, Decision append, and Proposal removal; after any injected failure or crash-recovery simulation, storage observes all effects or none.
+
+## Acceptance criteria
+
+- [ ] A general transaction seam exists in `crates/storage`
+- [ ] The concrete transaction implementation supports Proposal acceptance effects
+- [ ] `ProposalLifecycle::accept` uses the transaction seam instead of three independent writes
+- [ ] Failure-injection tests cover failure between each Proposal acceptance write
+- [ ] Tests assert on real temp-dir files after failure and after success
+- [ ] Retrying after an interrupted accept cannot duplicate a Decision
+- [ ] ADR-0003 remains linked from this issue
+- [ ] `task check` green
+
+## Blocked by
+
+043 — done by ADR-0003
+
+## User stories addressed
+
+- "When I accept a proposal and the process dies mid-commit, the next launch sees a consistent state — no orphaned focus, no double-recorded decision."

--- a/issues/048-focus-document-mutation-module.md
+++ b/issues/048-focus-document-mutation-module.md
@@ -1,0 +1,55 @@
+# 048 — FocusDocument mutation module
+
+## Parent PRD
+
+CONTEXT.md §Persistence + CLAUDE.md §Functional-first and §Data/view separation
+
+## What to build
+
+Deepen the markdown persistence implementation by extracting pure Focus document mutation out of `MarkdownFocusStore`.
+
+Today `crates/storage/src/focus_store.rs` owns both disk I/O and the rules for editing `focus.md`: replacing the frontmatter title, appending Task bullets, deleting indexed Task bullets, updating Task text, and toggling Task status. Those are document rules, not filesystem rules.
+
+### Target shape
+
+Add a pure module in `crates/storage`, for example `focus_document.rs`:
+
+```rust
+pub struct FocusDocument {
+    raw: String,
+}
+
+impl FocusDocument {
+    pub fn parse(raw: String) -> Result<Self, FocusDocumentError>;
+    pub fn rename_focus(&self, title: &str) -> Result<String, FocusDocumentError>;
+    pub fn append_task(&self, text: &str) -> Result<String, FocusDocumentError>;
+    pub fn delete_task(&self, index: usize) -> Result<String, FocusDocumentError>;
+    pub fn update_task(&self, index: usize, text: &str) -> Result<String, FocusDocumentError>;
+    pub fn toggle_task(&self, index: usize, done: bool) -> Result<String, FocusDocumentError>;
+}
+```
+
+Exact names may change. The interface should expose document operations and return the next raw document. It should not read or write files.
+
+`MarkdownFocusStore` should reduce to locating `focus.md`, reading raw text, calling `FocusDocument`, and writing the returned raw text atomically.
+
+## Completion promise
+
+All `focus.md` mutation rules live in a pure FocusDocument module; `MarkdownFocusStore` owns file placement and atomic writes, not line-editing logic.
+
+## Acceptance criteria
+
+- [ ] A pure FocusDocument module exists under `crates/storage/src/`
+- [ ] FocusDocument has unit tests for rename, append, delete, update, toggle, missing Task index, checked and unchecked Task preservation, and trailing-newline preservation
+- [ ] `MarkdownFocusStore::{rename_focus, append_task, delete_task, update_task, toggle_task}` delegate document mutation to FocusDocument
+- [ ] Existing `MarkdownFocusStore` tests still cover disk placement, missing Focus behavior, and atomic write integration
+- [ ] No parsing or mutation logic is moved into `crates/domain`; markdown shape stays a storage concern
+- [ ] `task check` green
+
+## Blocked by
+
+None
+
+## User stories addressed
+
+- "When markdown editing rules change, I can test them without filesystem setup and without touching every storage method."

--- a/issues/049-display-space-pig-movement-seam.md
+++ b/issues/049-display-space-pig-movement-seam.md
@@ -1,0 +1,50 @@
+# 049 — Display-space seam for Pig movement
+
+## Parent PRD
+
+CONTEXT.md §Core interaction loop step 8 (Configure displays)
+
+## What to build
+
+Deepen the display and Pig movement seam so React movement code no longer infers monitor behavior from raw viewport dimensions.
+
+Today Rust computes monitor span and a primary region, then React still owns display policy inside `usePigMovement`: spawn region, primary-display y ceiling, hard boundary clamping, hit-rect widening during drag, and the difference between overlay span and visible monitor regions. This makes cross-monitor behavior hard to reason about, especially with negative coordinates and portrait monitors.
+
+### Target shape
+
+Create a compact display-space model emitted from Rust and consumed by React:
+
+```ts
+interface DisplaySpace {
+  readonly span: { readonly w: number; readonly h: number };
+  readonly spawnRegion: Rect;
+  readonly movementRegions: readonly Rect[];
+  readonly hitTestScale: number;
+}
+```
+
+Rust should own monitor geometry: enabled monitor filtering, logical-coordinate span, primary spawn region, and movement regions. React should own motion over that display-space model: ticking velocity, random turns, drag/toss, and hit rect synchronization.
+
+The exact type names can change. The important seam is that `tickPig` should not need to know "if x is in the primary display, use a different y ceiling." It should ask a display-space helper to clamp or steer within allowed regions.
+
+## Completion promise
+
+Pig movement consumes a display-space interface instead of raw viewport dimensions and ad hoc primary-region rules; multi-monitor geometry policy is local to the display-space module.
+
+## Acceptance criteria
+
+- [ ] Rust emits a display-space payload that includes span, spawn region, and allowed movement regions
+- [ ] React has a pure display-space helper for clamp/steer decisions with unit tests
+- [ ] `tickPig` no longer hard-codes primary-display y ceiling logic
+- [ ] Tests cover single monitor, side-by-side monitors, negative-x monitor, portrait monitor, and monitor-above-primary geometry
+- [ ] Drag/toss still keeps the overlay interactive during active drag
+- [ ] Existing hit-rect tests remain green or are moved to the new helper
+- [ ] `task check` green
+
+## Blocked by
+
+None
+
+## User stories addressed
+
+- "When I add monitors in odd layouts, Pigs stay in visible display regions and the movement rules are testable without opening Tauri windows."

--- a/issues/050-settings-update-workflow.md
+++ b/issues/050-settings-update-workflow.md
@@ -1,0 +1,56 @@
+# 050 — Settings update workflow module
+
+## Parent PRD
+
+PRD.md §FR7 (configuration) + CLAUDE.md §Data/view separation
+
+## What to build
+
+Move settings update coordination out of the Tauri command handler and into a dedicated workflow module.
+
+Today `ui_bridge::update_settings` mutates in-memory Settings, persists `settings.yaml`, applies always-on-top behavior, updates display state, reapplies overlays, and rebuilds the tray menu inline. That makes the command handler the place where ordering and side effects live.
+
+### Target shape
+
+Add an app-side workflow module, for example `src-tauri/src/app/settings_workflow.rs`.
+
+The module should expose one high-leverage entry point:
+
+```rust
+pub struct SettingsWorkflow { /* injected adapters */ }
+
+impl SettingsWorkflow {
+    pub fn update(&self, next: Settings) -> Result<(), SettingsWorkflowError>;
+}
+```
+
+Adapters should cover:
+
+- in-memory Settings state
+- settings file persistence
+- overlay always-on-top application
+- display config reapply
+- tray menu rebuild
+
+The workflow owns ordering. A reasonable initial invariant: persist first, then update memory and apply runtime effects. If implementation chooses a different invariant, document it in tests.
+
+## Completion promise
+
+`ui_bridge::update_settings` delegates to a settings workflow module; settings persistence, in-memory update, display effects, and tray rebuild ordering are tested through one interface.
+
+## Acceptance criteria
+
+- [ ] `src-tauri/src/app/settings_workflow.rs` exists
+- [ ] `ui_bridge::update_settings` delegates to the workflow and contains no inline display/tray/window coordination
+- [ ] The workflow uses injected adapters or small helper traits for side effects
+- [ ] Tests cover persistence failure, display-change behavior, non-display widget setting behavior, and tray rebuild invocation
+- [ ] The chosen ordering invariant is documented in test names or code comments
+- [ ] `task check` green
+
+## Blocked by
+
+None
+
+## User stories addressed
+
+- "When settings change, the app applies one coherent workflow instead of scattering persistence and side effects through the command handler."

--- a/issues/README.md
+++ b/issues/README.md
@@ -22,8 +22,13 @@ Frontend reader collapse:
 Domain seams:
 
 - [041](041-focus-writer-write-outcome.md) — `FocusWriter` returns `WriteOutcome` (hands off to 029)
-- [043](043-proposal-lifecycle-atomicity-design.md) — `ProposalLifecycle::accept` atomicity (**HITL design** — produces ADR + follow-up)
+- [043](043-proposal-lifecycle-atomicity-design.md) — `ProposalLifecycle::accept` atomicity — **done** by [ADR-0003](../docs/adr/0003-storage-transaction-seam-for-proposal-lifecycle.md)
 - [044](044-domain-timer-ticker.md) — Carve domain `TimerTicker` pure module — **done** (merged, consumed by 029)
+- [046](046-timer-expiry-service-extraction.md) — Timer expiry workflow module
+- [047](047-storage-transaction-seam.md) — Storage transaction seam for Proposal lifecycle
+- [048](048-focus-document-mutation-module.md) — FocusDocument mutation module
+- [049](049-display-space-pig-movement-seam.md) — Display-space seam for Pig movement
+- [050](050-settings-update-workflow.md) — Settings update workflow module
 
 Closed without implementation:
 


### PR DESCRIPTION
## What changed

- Added ADR-0003 choosing a general storage transaction seam for Proposal lifecycle writes.
- Added AFK-ready architecture issues 047-050.
- Updated issue 046 with a completion promise and user story so the architecture queue captures all five deepening opportunities.
- Updated `issues/README.md` to mark issue 043 done by ADR-0003 and list issues 046-050.

## Why

The repo is moving toward more complex Focus, Task, Proposal, Pig, FocusTimer, TimerPreset, Decision, and Settings workflows. These docs capture the next deepening slices before AFK implementation agents pick them up.

## Validation

- Reviewed the new ADR and issue contracts against `CONTEXT.md`, `PRD.md`, `CLAUDE.md`, and the existing ADRs.
- Ran `rtk git status --short --branch` before publishing; the branch contained only the intended docs/issue changes.
- No test suite run; docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design docs and specs improving reliability and behavior for proposal acceptance (atomic commits), timer expiry handling, settings update workflow, markdown focus mutations, and display-space for on-screen item movement.
* **Chores**
  * Adjusted CI workflow caching configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/56)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->