### PR TITLE
[display-space-ranchanimal-movement]: Display-space seam for RanchAnimal movement

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,14 @@ A top-level item the user is paying attention to. Represents a real-world goal (
 
 The visual representation of a Focus. A pixel-art sprite that wanders the screen. One pig = one Focus. Clicking a pig opens its detail card. Pigs are not stored — they are ephemeral projections of Focus state.
 
+### RanchAnimal
+
+The broader visual projection family for Focuses. Pig is the only implemented RanchAnimal today, but future versions may render other animals with different sprites or movement feel. Shared movement and display rules should use animal-neutral names where practical; Pig-specific names should remain only at the current sprite/UI Adapter.
+
+### DisplaySpace
+
+The normalized layout of enabled monitors within the spanning overlay window. Defines the overlay span, the primary spawn region, and the actual visible monitor regions where RanchAnimals may move. RanchAnimals are constrained to monitor regions, not the full rectangular span, so odd layouts do not allow invisible wandering through gaps between displays. If a RanchAnimal is outside every movement region after a display change, it moves to the nearest valid point in any enabled movement region. At movement-region edges, RanchAnimals soft-steer before impact for a natural wandering feel, then hard-clamp and reflect velocity if they still cross outside a valid region.
+
 ### Task
 
 A child item under a Focus. Single sentence. Created by user action or (v1.3+) by an accepted `add_task` proposal. Tree is capped at two levels — Focus → Task. No sub-tasks. Removed only by user action.

--- a/issues/049-display-space-pig-movement-seam.md
+++ b/issues/049-display-space-pig-movement-seam.md
@@ -1,4 +1,4 @@
-# 049 — Display-space seam for Pig movement
+# 049 — Display-space seam for RanchAnimal movement
 
 ## Parent PRD
 
@@ -6,9 +6,9 @@ CONTEXT.md §Core interaction loop step 8 (Configure displays)
 
 ## What to build
 
-Deepen the display and Pig movement seam so React movement code no longer infers monitor behavior from raw viewport dimensions.
+Deepen the display and RanchAnimal movement seam so React movement code no longer infers monitor behavior from raw viewport dimensions.
 
-Today Rust computes monitor span and a primary region, then React still owns display policy inside `usePigMovement`: spawn region, primary-display y ceiling, hard boundary clamping, hit-rect widening during drag, and the difference between overlay span and visible monitor regions. This makes cross-monitor behavior hard to reason about, especially with negative coordinates and portrait monitors.
+Today Rust computes monitor span and a primary region, then React still owns display policy inside `usePigMovement`: spawn region, primary-display y ceiling, hard boundary clamping, hit-rect widening during drag, and the difference between overlay span and visible monitor regions. This makes cross-monitor behavior hard to reason about, especially with negative coordinates and portrait monitors. Pig is the only implemented RanchAnimal today, but this seam should avoid Pig-specific names where the behavior applies to future animal projections. Per-animal movement profiles are explicitly out of scope for this slice; all RanchAnimals use one shared movement rule set for now.
 
 ### Target shape
 
@@ -23,23 +23,29 @@ interface DisplaySpace {
 }
 ```
 
-Rust should own monitor geometry: enabled monitor filtering, logical-coordinate span, primary spawn region, and movement regions. React should own motion over that display-space model: ticking velocity, random turns, drag/toss, and hit rect synchronization.
+Rust should own monitor geometry: enabled monitor filtering, logical-coordinate span, primary spawn region, and movement regions. Movement regions are the actual visible enabled-monitor rectangles normalized into overlay coordinates; they are not the full rectangular span. React should own motion over that display-space model through a deep movement-step module: given a RanchAnimal, DisplaySpace, elapsed time, current time, randomness Adapter, and shared movement options, it returns the next RanchAnimal state. The hook should stay a thin Adapter for React state, animation frames, Tauri subscriptions, and hit rect synchronization.
 
-The exact type names can change. The important seam is that `tickPig` should not need to know "if x is in the primary display, use a different y ceiling." It should ask a display-space helper to clamp or steer within allowed regions.
+The exact type names can change. The important seam is that `tickPig` should not need to know "if x is in the primary display, use a different y ceiling." It should delegate movement sequencing to the movement-step module rather than stitching together raw geometry helpers. If a RanchAnimal's current position becomes invalid after a display change, that module should move it to the nearest valid point in any movement region rather than respawning it.
+
+Movement edge behavior is hybrid: soft-steer near movement-region edges so wandering still feels natural, then hard-clamp and reflect velocity if a RanchAnimal still crosses outside the allowed regions.
 
 ## Completion promise
 
-Pig movement consumes a display-space interface instead of raw viewport dimensions and ad hoc primary-region rules; multi-monitor geometry policy is local to the display-space module.
+RanchAnimal movement consumes a display-space interface instead of raw viewport dimensions and ad hoc primary-region rules; multi-monitor geometry policy is local to the display-space module.
 
 ## Acceptance criteria
 
-- [ ] Rust emits a display-space payload that includes span, spawn region, and allowed movement regions
-- [ ] React has a pure display-space helper for clamp/steer decisions with unit tests
-- [ ] `tickPig` no longer hard-codes primary-display y ceiling logic
-- [ ] Tests cover single monitor, side-by-side monitors, negative-x monitor, portrait monitor, and monitor-above-primary geometry
-- [ ] Drag/toss still keeps the overlay interactive during active drag
-- [ ] Existing hit-rect tests remain green or are moved to the new helper
-- [ ] `task check` green
+- [x] Rust emits a display-space payload that includes span, spawn region, and allowed movement regions
+- [x] Allowed movement regions are normalized visible monitor rectangles, so RanchAnimals cannot enter invisible gaps inside the overlay span
+- [x] React has a pure movement-step module for roam/freeze/friction/turn/soft-steer/hard-clamp decisions with unit tests
+- [x] The movement-step interface accepts randomness as an Adapter so turn timing and direction are deterministic in tests
+- [x] Invalid RanchAnimal positions after display changes are clamped to the nearest valid point in any movement region
+- [x] Movement uses hybrid edge behavior: soft steering near region edges, hard clamp/reflect after crossing
+- [x] `tickPig` no longer hard-codes primary-display y ceiling logic
+- [x] Tests cover single monitor, side-by-side monitors, negative-x monitor, portrait monitor, and monitor-above-primary geometry
+- [x] Drag/toss still keeps the overlay interactive during active drag
+- [x] Existing hit-rect tests remain green or are moved to the new helper
+- [x] `task check` green
 
 ## Blocked by
 
@@ -47,4 +53,4 @@ None
 
 ## User stories addressed
 
-- "When I add monitors in odd layouts, Pigs stay in visible display regions and the movement rules are testable without opening Tauri windows."
+- "When I add monitors in odd layouts, RanchAnimals stay in visible display regions and the movement rules are testable without opening Tauri windows."

--- a/src-tauri/src/display/mod.rs
+++ b/src-tauri/src/display/mod.rs
@@ -7,23 +7,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use adhd_ranch_domain::{DisplayConfig, PigRect, RectUpdater};
-use serde::Serialize;
 use tauri::{AppHandle, Wry};
 
 use hit_test::PigHitTester;
 use monitor::LogicalMonitor;
 
 const OVERLAY_LABEL: &str = "overlay-0";
-
-/// CSS-space region of the first enabled monitor within the spanning overlay window.
-/// Sent to React so pig spawning is confined to a visible display.
-#[derive(Serialize, Clone, Debug)]
-pub struct PrimaryRegion {
-    pub x: f64,
-    pub y: f64,
-    pub w: f64,
-    pub h: f64,
-}
 
 struct OverlayEntry {
     tester: PigHitTester,
@@ -84,18 +73,12 @@ impl DisplayService for DisplayManager {
             return;
         }
 
-        let bounds =
-            monitor::compute_span(&enabled.iter().map(|m| (*m).clone()).collect::<Vec<_>>());
-
-        // CSS offset of first enabled monitor within the span.
-        let primary = enabled[0];
-        let primary_region = PrimaryRegion {
-            x: primary.position.0 - bounds.x,
-            y: primary.position.1 - bounds.y,
-            w: primary.size.0,
-            h: primary.size.1,
+        let Some((display_space, bounds)) =
+            monitor::compute_display_space(monitors, &config.enabled_indices)
+        else {
+            return;
         };
-        log::info!("display: primary_region={primary_region:?}");
+        log::info!("display: display_space={display_space:?}");
 
         let already_managed = self
             .entries
@@ -138,7 +121,7 @@ impl DisplayService for DisplayManager {
                 height: bounds.height,
                 tester: &tester,
                 already_managed,
-                primary_region: &primary_region,
+                display_space: &display_space,
                 drag_active: Arc::clone(&self.drag_active),
                 stop,
             },

--- a/src-tauri/src/display/monitor.rs
+++ b/src-tauri/src/display/monitor.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 #[derive(Clone, Debug)]
 pub struct LogicalMonitor {
     pub index: usize,
@@ -40,6 +42,29 @@ pub struct SpanBounds {
     pub height: f64,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DisplaySpan {
+    pub w: f64,
+    pub h: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DisplayRect {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplaySpace {
+    pub span: DisplaySpan,
+    pub spawn_region: DisplayRect,
+    pub movement_regions: Vec<DisplayRect>,
+    pub hit_test_scale: f64,
+}
+
 pub fn compute_span(monitors: &[LogicalMonitor]) -> SpanBounds {
     let min_x = monitors
         .iter()
@@ -64,6 +89,40 @@ pub fn compute_span(monitors: &[LogicalMonitor]) -> SpanBounds {
         width: (max_x - min_x).max(1.0),
         height: (max_y - min_y).max(1.0),
     }
+}
+
+pub fn compute_display_space(
+    monitors: &[LogicalMonitor],
+    enabled_indices: &[usize],
+) -> Option<(DisplaySpace, SpanBounds)> {
+    let enabled: Vec<&LogicalMonitor> = monitors
+        .iter()
+        .filter(|m| enabled_indices.contains(&m.index))
+        .collect();
+    if enabled.is_empty() {
+        return None;
+    }
+
+    let bounds = compute_span(&enabled.iter().map(|m| (*m).clone()).collect::<Vec<_>>());
+    let to_rect = |m: &LogicalMonitor| DisplayRect {
+        x: m.position.0 - bounds.x,
+        y: m.position.1 - bounds.y,
+        w: m.size.0,
+        h: m.size.1,
+    };
+    let primary = enabled[0];
+
+    let display_space = DisplaySpace {
+        span: DisplaySpan {
+            w: bounds.width,
+            h: bounds.height,
+        },
+        spawn_region: to_rect(primary),
+        movement_regions: enabled.iter().map(|m| to_rect(m)).collect(),
+        hit_test_scale: primary.scale_factor,
+    };
+
+    Some((display_space, bounds))
 }
 
 pub fn disambiguate_names(monitors: &mut [LogicalMonitor]) {
@@ -145,6 +204,168 @@ mod tests {
         assert_eq!(span.y, 0.0);
         assert_eq!(span.width, 3200.0); // 1920 + 1280
         assert_eq!(span.height, 1080.0);
+    }
+
+    #[test]
+    fn display_space_normalizes_enabled_monitor_regions_into_overlay_coordinates() {
+        let monitors = vec![
+            mon(0, (0.0, 0.0), (1920.0, 1080.0)),
+            mon(1, (-1280.0, 0.0), (1280.0, 800.0)),
+        ];
+        let (space, _bounds) = compute_display_space(&monitors, &[0, 1]).unwrap();
+
+        assert_eq!(
+            space.span,
+            DisplaySpan {
+                w: 3200.0,
+                h: 1080.0
+            }
+        );
+        assert_eq!(
+            space.spawn_region,
+            DisplayRect {
+                x: 1280.0,
+                y: 0.0,
+                w: 1920.0,
+                h: 1080.0
+            }
+        );
+        assert_eq!(
+            space.movement_regions,
+            vec![
+                DisplayRect {
+                    x: 1280.0,
+                    y: 0.0,
+                    w: 1920.0,
+                    h: 1080.0
+                },
+                DisplayRect {
+                    x: 0.0,
+                    y: 0.0,
+                    w: 1280.0,
+                    h: 800.0
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn display_space_single_monitor_uses_the_monitor_as_span_spawn_and_movement() {
+        let monitors = vec![mon(0, (0.0, 0.0), (1920.0, 1080.0))];
+        let (space, _bounds) = compute_display_space(&monitors, &[0]).unwrap();
+
+        assert_eq!(
+            space.span,
+            DisplaySpan {
+                w: 1920.0,
+                h: 1080.0
+            }
+        );
+        assert_eq!(
+            space.spawn_region,
+            DisplayRect {
+                x: 0.0,
+                y: 0.0,
+                w: 1920.0,
+                h: 1080.0
+            }
+        );
+        assert_eq!(space.movement_regions, vec![space.spawn_region.clone()]);
+    }
+
+    #[test]
+    fn display_space_side_by_side_regions_are_not_collapsed_into_one_span_rect() {
+        let monitors = vec![
+            mon(0, (0.0, 0.0), (1920.0, 1080.0)),
+            mon(1, (1920.0, 0.0), (2560.0, 1440.0)),
+        ];
+        let (space, _bounds) = compute_display_space(&monitors, &[0, 1]).unwrap();
+
+        assert_eq!(
+            space.span,
+            DisplaySpan {
+                w: 4480.0,
+                h: 1440.0
+            }
+        );
+        assert_eq!(space.movement_regions.len(), 2);
+        assert_eq!(
+            space.movement_regions[1],
+            DisplayRect {
+                x: 1920.0,
+                y: 0.0,
+                w: 2560.0,
+                h: 1440.0
+            }
+        );
+    }
+
+    #[test]
+    fn display_space_portrait_left_keeps_separate_visible_regions() {
+        let monitors = vec![
+            mon(0, (0.0, 0.0), (2560.0, 1440.0)),
+            mon(1, (-1080.0, 0.0), (1080.0, 1920.0)),
+        ];
+        let (space, _bounds) = compute_display_space(&monitors, &[0, 1]).unwrap();
+
+        assert_eq!(
+            space.span,
+            DisplaySpan {
+                w: 3640.0,
+                h: 1920.0
+            }
+        );
+        assert_eq!(
+            space.movement_regions,
+            vec![
+                DisplayRect {
+                    x: 1080.0,
+                    y: 0.0,
+                    w: 2560.0,
+                    h: 1440.0
+                },
+                DisplayRect {
+                    x: 0.0,
+                    y: 0.0,
+                    w: 1080.0,
+                    h: 1920.0
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn display_space_monitor_above_primary_normalizes_negative_y() {
+        let monitors = vec![
+            mon(0, (0.0, 0.0), (2560.0, 1440.0)),
+            mon(1, (500.0, -1920.0), (1080.0, 1920.0)),
+        ];
+        let (space, _bounds) = compute_display_space(&monitors, &[0, 1]).unwrap();
+
+        assert_eq!(
+            space.span,
+            DisplaySpan {
+                w: 2560.0,
+                h: 3360.0
+            }
+        );
+        assert_eq!(
+            space.movement_regions,
+            vec![
+                DisplayRect {
+                    x: 0.0,
+                    y: 1920.0,
+                    w: 2560.0,
+                    h: 1440.0
+                },
+                DisplayRect {
+                    x: 500.0,
+                    y: 0.0,
+                    w: 1080.0,
+                    h: 1920.0
+                },
+            ]
+        );
     }
 
     // Test 4: portrait monitor (270° rotated, height > width) left of landscape

--- a/src-tauri/src/display/overlay.rs
+++ b/src-tauri/src/display/overlay.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, Wry};
 
 use super::hit_test::PigHitTester;
-use super::PrimaryRegion;
+use super::monitor::DisplaySpace;
 
 const OVERLAY_LABEL: &str = "overlay-0";
 
@@ -16,7 +16,7 @@ pub struct ShowParams<'a> {
     pub height: f64,
     pub tester: &'a PigHitTester,
     pub already_managed: bool,
-    pub primary_region: &'a PrimaryRegion,
+    pub display_space: &'a DisplaySpace,
     pub drag_active: Arc<AtomicBool>,
     /// Signals the hit-test poller to exit when set to true.
     pub stop: Arc<AtomicBool>,
@@ -30,7 +30,7 @@ pub fn ensure_shown(app: &AppHandle<Wry>, p: ShowParams<'_>) -> tauri::Result<()
         height,
         tester,
         already_managed,
-        primary_region,
+        display_space,
         drag_active,
         stop,
     } = p;
@@ -97,9 +97,9 @@ pub fn ensure_shown(app: &AppHandle<Wry>, p: ShowParams<'_>) -> tauri::Result<()
     let sf = window.scale_factor().unwrap_or(0.0);
     log::info!("overlay: window scale_factor={sf}");
 
-    // Always emit primary region so React knows where to spawn pigs.
-    // Re-emitted on display toggle so React updates the spawn zone.
-    let _ = window.emit("display-region", primary_region.clone());
+    // Always emit display-space so React knows where animals can spawn and move.
+    // Re-emitted on display toggle so React updates the movement model.
+    let _ = window.emit("display-space", display_space.clone());
 
     if !already_managed {
         let tester_thread = tester.clone();

--- a/src/api/pig.ts
+++ b/src/api/pig.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { PigHitRect, SpawnRegion } from "../types/pig";
+import type { DisplaySpace } from "../types/display";
+import type { PigHitRect } from "../types/pig";
 
 export type Unsubscribe = () => void;
 
@@ -16,8 +17,8 @@ export async function subscribeGatherPigs(cb: () => void): Promise<Unsubscribe> 
   return listen("gather-pigs", () => cb());
 }
 
-export async function subscribeDisplayRegion(
-  cb: (region: SpawnRegion) => void,
+export async function subscribeDisplaySpace(
+  cb: (space: DisplaySpace) => void,
 ): Promise<Unsubscribe> {
-  return listen<SpawnRegion>("display-region", (event) => cb(event.payload));
+  return listen<DisplaySpace>("display-space", (event) => cb(event.payload));
 }

--- a/src/hooks/usePigMovement.ts
+++ b/src/hooks/usePigMovement.ts
@@ -1,28 +1,31 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   setPigDragActive,
-  subscribeDisplayRegion,
+  subscribeDisplaySpace,
   subscribeGatherPigs,
   updatePigRects,
 } from "../api/pig";
+import {
+  RANCH_ANIMAL_SIZE,
+  RANCH_ANIMAL_SPEED,
+  type RanchAnimalDirection,
+  type RanchAnimalState,
+  advanceRanchAnimal,
+} from "../lib/ranchAnimalMovement";
+import type { DisplaySpace } from "../types/display";
 import type { Focus } from "../types/focus";
-import type { PigHitRect, SpawnRegion } from "../types/pig";
+import type { PigHitRect } from "../types/pig";
 
-export type { PigHitRect, SpawnRegion };
+export type { DisplaySpace, PigHitRect };
 
-export const PIG_SIZE = 48;
+export const PIG_SIZE = RANCH_ANIMAL_SIZE;
 export const HITBOX_PADDING = 16;
 export const DRAG_THRESHOLD = 4;
 export const TOSS_VELOCITY_WINDOW_MS = 80;
-export const FRICTION = 0.97;
 
-export const PIG_SPEED = 60; // px/s — fast enough to look alive across large spans
-const MIN_SPEED_FRAC = 0.35; // friction floor: never drop below this fraction of PIG_SPEED
+export const PIG_SPEED = RANCH_ANIMAL_SPEED; // px/s — fast enough to look alive across large spans
 const EDGE_MARGIN = 60; // px from screen edge
 
-const FRAME_INTERVAL = 150; // ms per animation frame
-const MIN_TURN_MS = 3000;
-const MAX_TURN_MS = 8000;
 const RECT_UPDATE_EVERY = 4; // rAF frames between pig-rect syncs to Rust
 
 export interface PointerSample {
@@ -53,20 +56,9 @@ export function computeTossVelocity(
   return { vx, vy };
 }
 
-export type PigDirection = "front" | "right" | "back" | "left";
+export type PigDirection = RanchAnimalDirection;
 
-export interface PigState {
-  id: string;
-  name: string;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  frameIndex: number;
-  direction: PigDirection;
-  lastFrameAt: number;
-  nextTurnAt: number;
-}
+export type PigState = RanchAnimalState;
 
 export interface PigMovementResult {
   pigs: PigState[];
@@ -81,11 +73,8 @@ function direction4(vx: number, vy: number): PigDirection {
   return vy >= 0 ? "front" : "back";
 }
 
-function randomTurnDelay(): number {
-  return MIN_TURN_MS + Math.random() * (MAX_TURN_MS - MIN_TURN_MS);
-}
-
-function initPig(focus: Focus, region: SpawnRegion, now: number): PigState {
+function initPig(focus: Focus, displaySpace: DisplaySpace, now: number): PigState {
+  const region = displaySpace.spawnRegion;
   const angle = Math.random() * 2 * Math.PI;
   const vx = Math.cos(angle) * PIG_SPEED;
   const vy = Math.sin(angle) * PIG_SPEED;
@@ -99,102 +88,8 @@ function initPig(focus: Focus, region: SpawnRegion, now: number): PigState {
     frameIndex: 0,
     direction: direction4(vx, vy),
     lastFrameAt: now,
-    nextTurnAt: now + randomTurnDelay(),
+    nextTurnAt: now + 3000 + Math.random() * 5000,
   };
-}
-
-function tickPig(
-  pig: PigState,
-  dt: number,
-  now: number,
-  screenW: number,
-  screenH: number,
-  frozen: boolean,
-  primaryRegion: SpawnRegion,
-): PigState {
-  // Advance timers while frozen so nextTurnAt/lastFrameAt don't expire during
-  // the pause, preventing an immediate turn or frame jump on unfreeze.
-  if (frozen) {
-    return {
-      ...pig,
-      nextTurnAt: pig.nextTurnAt + dt,
-      lastFrameAt: pig.lastFrameAt + dt,
-    };
-  }
-  let { x, y, vx, vy, frameIndex, lastFrameAt, nextTurnAt, direction } = pig;
-
-  // Apply friction so toss velocity decelerates naturally.
-  vx *= FRICTION;
-  vy *= FRICTION;
-
-  // Enforce minimum speed so pigs never look frozen between turns.
-  const speed = Math.sqrt(vx * vx + vy * vy);
-  const minSpeed = PIG_SPEED * MIN_SPEED_FRAC;
-  if (speed < minSpeed && speed > 0) {
-    const scale = minSpeed / speed;
-    vx *= scale;
-    vy *= scale;
-  } else if (speed === 0) {
-    const angle = Math.random() * 2 * Math.PI;
-    vx = Math.cos(angle) * minSpeed;
-    vy = Math.sin(angle) * minSpeed;
-  }
-
-  // Random direction change
-  if (now >= nextTurnAt) {
-    const angle = Math.random() * 2 * Math.PI;
-    vx = Math.cos(angle) * PIG_SPEED;
-    vy = Math.sin(angle) * PIG_SPEED;
-    nextTurnAt = now + randomTurnDelay();
-  }
-
-  // Effective y ceiling: when pig is in the primary-display x-range it must stay
-  // within the primary display height. Outside that x-range (e.g. portrait monitor
-  // to the left) the full span height is available.
-  const inPrimary = x >= primaryRegion.x && x <= primaryRegion.x + primaryRegion.w;
-  const effectiveMaxY = inPrimary ? primaryRegion.y + primaryRegion.h : screenH;
-
-  // Soft boundary steering: blend away-from-edge velocity when within margin
-  if (x < EDGE_MARGIN) vx = Math.abs(vx) || PIG_SPEED * 0.5;
-  if (x > screenW - EDGE_MARGIN - PIG_SIZE) vx = -(Math.abs(vx) || PIG_SPEED * 0.5);
-  if (y < EDGE_MARGIN) vy = Math.abs(vy) || PIG_SPEED * 0.5;
-  if (y > effectiveMaxY - EDGE_MARGIN - PIG_SIZE) vy = -(Math.abs(vy) || PIG_SPEED * 0.5);
-
-  // Clamp to max toss speed.
-  const speed2 = Math.sqrt(vx * vx + vy * vy);
-  if (speed2 > PIG_SPEED * 6) {
-    vx = (vx / speed2) * PIG_SPEED * 6;
-    vy = (vy / speed2) * PIG_SPEED * 6;
-  }
-
-  // Update position and reflect velocity at hard boundaries so pigs never escape.
-  x += vx * (dt / 1000);
-  y += vy * (dt / 1000);
-  if (x < 0) {
-    x = 0;
-    vx = Math.abs(vx);
-  }
-  if (x > screenW - PIG_SIZE) {
-    x = screenW - PIG_SIZE;
-    vx = -Math.abs(vx);
-  }
-  if (y < 0) {
-    y = 0;
-    vy = Math.abs(vy);
-  }
-  if (y > effectiveMaxY - PIG_SIZE) {
-    y = effectiveMaxY - PIG_SIZE;
-    vy = -Math.abs(vy);
-  }
-
-  direction = direction4(vx, vy);
-
-  if (now - lastFrameAt >= FRAME_INTERVAL) {
-    frameIndex = (frameIndex + 1) % 4;
-    lastFrameAt = now;
-  }
-
-  return { ...pig, x, y, vx, vy, frameIndex, direction, lastFrameAt, nextTurnAt };
 }
 
 export function buildHitRects(pigs: PigState[], dpr: number): PigHitRect[] {
@@ -205,19 +100,25 @@ export function buildHitRects(pigs: PigState[], dpr: number): PigHitRect[] {
   }));
 }
 
-function syncRects(pigs: PigState[], wide: boolean): void {
-  const dpr = window.devicePixelRatio || 1;
+function syncRects(pigs: PigState[], wide: boolean, displaySpace: DisplaySpace): void {
+  const scale = displaySpace.hitTestScale;
   // Wide rect (detail open or dragging) keeps overlay interactive across the full viewport.
   const rects = wide
-    ? [{ x: 0, y: 0, size: Math.max(window.innerWidth, window.innerHeight) * dpr * 2 }]
-    : buildHitRects(pigs, dpr);
+    ? [{ x: 0, y: 0, size: Math.max(displaySpace.span.w, displaySpace.span.h) * scale * 2 }]
+    : buildHitRects(pigs, scale);
   updatePigRects(rects).catch(() => {});
 }
 
-function defaultRegion(): SpawnRegion {
+function defaultDisplaySpace(): DisplaySpace {
   const w = document.documentElement.clientWidth || window.screen.width;
   const h = document.documentElement.clientHeight || window.screen.height;
-  return { x: 0, y: 0, w, h };
+  const region = { x: 0, y: 0, w, h };
+  return {
+    span: { w, h },
+    spawnRegion: region,
+    movementRegions: [region],
+    hitTestScale: window.devicePixelRatio || 1,
+  };
 }
 
 export function usePigMovement(
@@ -230,8 +131,15 @@ export function usePigMovement(
   const rafRef = useRef<number>(0);
   const lastTimeRef = useRef<number>(performance.now());
   const frameCountRef = useRef<number>(0);
-  // Region is updated via setRegion when Rust emits display-region.
-  const regionRef = useRef<SpawnRegion>(defaultRegion());
+  const fallbackDisplaySpaceRef = useRef<DisplaySpace | null>(null);
+  const [displaySpace, setDisplaySpaceState] = useState<DisplaySpace>(() => {
+    const space = defaultDisplaySpace();
+    fallbackDisplaySpaceRef.current = space;
+    return space;
+  });
+  // DisplaySpace is updated when Rust emits display-space.
+  const displaySpaceRef = useRef<DisplaySpace>(displaySpace);
+  const spawnedFromFallbackRef = useRef<Set<string>>(new Set());
 
   // Drag state — refs to avoid stale closures in the rAF loop.
   const dragIdRef = useRef<string | null>(null);
@@ -241,8 +149,9 @@ export function usePigMovement(
   // Keep selectedId ref in sync so the rAF loop sees the latest value without restarting.
   selectedIdRef.current = selectedId;
 
-  const setRegion = useCallback((r: SpawnRegion) => {
-    regionRef.current = r;
+  const setDisplaySpace = useCallback((space: DisplaySpace) => {
+    displaySpaceRef.current = space;
+    setDisplaySpaceState(space);
   }, []);
 
   const setDragActive = useCallback((active: boolean) => {
@@ -256,7 +165,7 @@ export function usePigMovement(
     // Widen hit-rect immediately so the overlay stays interactive during the drag.
     // Without this there is a ~67ms window where the window is click-through,
     // which breaks pointer capture when crossing monitor boundaries.
-    syncRects(pigsRef.current, true);
+    syncRects(pigsRef.current, true, displaySpaceRef.current);
   }, []);
 
   const moveDrag = useCallback((x: number, y: number) => {
@@ -277,7 +186,7 @@ export function usePigMovement(
 
   const gather = useCallback(() => {
     setPigs((prev) => {
-      const r = regionRef.current;
+      const r = displaySpaceRef.current.spawnRegion;
       const margin = 20;
       const rowHeight = PIG_SIZE + 24;
       const colWidth = PIG_SIZE + 24;
@@ -319,7 +228,7 @@ export function usePigMovement(
       const next = prev.map((p) => (p.id === pigId ? { ...p, vx, vy } : p));
       pigsRef.current = next;
       // Restore narrow rects immediately so hit-test is precise again.
-      syncRects(next, false);
+      syncRects(next, false, displaySpaceRef.current);
       return next;
     });
 
@@ -328,18 +237,33 @@ export function usePigMovement(
 
   // Sync pig list to focuses: add spawns for new, remove for deleted.
   useEffect(() => {
-    const region = regionRef.current;
     const now = performance.now();
 
     setPigs((prev) => {
       const prevMap = new Map(prev.map((p) => [p.id, p]));
-      const next = focuses.map((f) => prevMap.get(f.id) ?? initPig(f, region, now));
+      const fallbackIds = spawnedFromFallbackRef.current;
+      const nextFallbackIds = new Set<string>();
+      const next = focuses.map((f) => {
+        const existing = prevMap.get(f.id);
+        const usingFallback = displaySpace === fallbackDisplaySpaceRef.current;
+        if (existing && (!fallbackIds.has(f.id) || usingFallback)) {
+          if (fallbackIds.has(f.id)) nextFallbackIds.add(f.id);
+          return existing;
+        }
+
+        const pig = initPig(f, displaySpace, now);
+        if (usingFallback) {
+          nextFallbackIds.add(f.id);
+        }
+        return pig;
+      });
+      spawnedFromFallbackRef.current = nextFallbackIds;
       pigsRef.current = next;
       return next;
     });
-  }, [focuses]);
+  }, [focuses, displaySpace]);
 
-  // Subscribe to gather-pigs / display-region events from Rust.
+  // Subscribe to gather-pigs / display-space events from Rust.
   // Fall back to a no-op unsubscribe if subscribe rejects so cleanup never throws.
   useEffect(() => {
     const unsubPromise = subscribeGatherPigs(gather).catch(() => () => {});
@@ -349,11 +273,11 @@ export function usePigMovement(
   }, [gather]);
 
   useEffect(() => {
-    const unsubPromise = subscribeDisplayRegion(setRegion).catch(() => () => {});
+    const unsubPromise = subscribeDisplaySpace(setDisplaySpace).catch(() => () => {});
     return () => {
       unsubPromise.then((unsub) => unsub());
     };
-  }, [setRegion]);
+  }, [setDisplaySpace]);
 
   // rAF movement loop
   useEffect(() => {
@@ -361,14 +285,18 @@ export function usePigMovement(
       const dt = Math.min(now - lastTimeRef.current, 100);
       lastTimeRef.current = now;
 
-      const screenW = document.documentElement.clientWidth || window.screen.width;
-      const screenH = document.documentElement.clientHeight || window.screen.height;
-
-      const region = regionRef.current;
+      const displaySpace = displaySpaceRef.current;
       const updated = pigsRef.current.map((p) => {
         // Skip tick for dragged pig — position is driven by pointer events.
         if (p.id === dragIdRef.current) return p;
-        return tickPig(p, dt, now, screenW, screenH, p.id === selectedIdRef.current, region);
+        return advanceRanchAnimal({
+          animal: p,
+          displaySpace,
+          dtMs: dt,
+          nowMs: now,
+          frozen: p.id === selectedIdRef.current,
+          random: Math.random,
+        });
       });
       pigsRef.current = updated;
       setPigs(updated);
@@ -376,7 +304,7 @@ export function usePigMovement(
       frameCountRef.current += 1;
       if (frameCountRef.current % RECT_UPDATE_EVERY === 0) {
         const wide = selectedIdRef.current !== null || dragIdRef.current !== null;
-        syncRects(updated, wide);
+        syncRects(updated, wide, displaySpace);
       }
 
       rafRef.current = requestAnimationFrame(loop);

--- a/src/lib/ranchAnimalMovement.test.ts
+++ b/src/lib/ranchAnimalMovement.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { DisplaySpace } from "../types/display";
+import { type RanchAnimalState, advanceRanchAnimal } from "./ranchAnimalMovement";
+
+const displaySpace: DisplaySpace = {
+  span: { w: 3200, h: 1080 },
+  spawnRegion: { x: 1280, y: 0, w: 1920, h: 1080 },
+  movementRegions: [
+    { x: 1280, y: 0, w: 1920, h: 1080 },
+    { x: 0, y: 0, w: 1280, h: 800 },
+  ],
+  hitTestScale: 2,
+};
+
+const animal = (overrides?: Partial<RanchAnimalState>): RanchAnimalState => ({
+  id: "a",
+  name: "Alpha",
+  x: 1300,
+  y: 100,
+  vx: 60,
+  vy: 0,
+  frameIndex: 0,
+  direction: "right",
+  lastFrameAt: 0,
+  nextTurnAt: 3000,
+  ...overrides,
+});
+
+describe("advanceRanchAnimal", () => {
+  it("clamps an invalid position to the nearest movement region", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 1000, y: 900, vx: 0, vy: 0 }),
+      displaySpace,
+      dtMs: 0,
+      nowMs: 0,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(next.x).toBe(1000);
+    expect(next.y).toBe(800 - 48);
+  });
+
+  it("hard-clamps and reflects velocity after crossing a movement-region edge", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 80, y: 40, vx: 120, vy: 0, nextTurnAt: 3000 }),
+      displaySpace: {
+        span: { w: 200, h: 200 },
+        spawnRegion: { x: 0, y: 0, w: 200, h: 200 },
+        movementRegions: [{ x: 0, y: 0, w: 200, h: 200 }],
+        hitTestScale: 1,
+      },
+      dtMs: 1000,
+      nowMs: 1000,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(next.x).toBe(200 - 48);
+    expect(next.vx).toBeLessThan(0);
+  });
+
+  it("soft-steers away from a movement-region edge before impact", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 120, y: 40, vx: 60, vy: 0, nextTurnAt: 3000 }),
+      displaySpace: {
+        span: { w: 200, h: 200 },
+        spawnRegion: { x: 0, y: 0, w: 200, h: 200 },
+        movementRegions: [{ x: 0, y: 0, w: 200, h: 200 }],
+        hitTestScale: 1,
+      },
+      dtMs: 0,
+      nowMs: 1000,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(next.vx).toBeLessThan(0);
+  });
+
+  it("uses the randomness adapter for turn direction and next turn timing", () => {
+    const values = [0, 0];
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 80, y: 80, vx: 0, vy: 0, nextTurnAt: 1000 }),
+      displaySpace: {
+        span: { w: 400, h: 400 },
+        spawnRegion: { x: 0, y: 0, w: 400, h: 400 },
+        movementRegions: [{ x: 0, y: 0, w: 400, h: 400 }],
+        hitTestScale: 1,
+      },
+      dtMs: 0,
+      nowMs: 1000,
+      frozen: false,
+      random: () => values.shift() ?? 0,
+    });
+
+    expect(next.vx).toBeGreaterThan(0);
+    expect(next.vy).toBeCloseTo(0);
+    expect(next.nextTurnAt).toBe(4000);
+  });
+
+  it("does not move while frozen but advances movement timers", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 80, y: 80, vx: 60, vy: 0, lastFrameAt: 100, nextTurnAt: 3000 }),
+      displaySpace,
+      dtMs: 250,
+      nowMs: 1000,
+      frozen: true,
+      random: () => 0,
+    });
+
+    expect(next.x).toBe(80);
+    expect(next.y).toBe(80);
+    expect(next.lastFrameAt).toBe(350);
+    expect(next.nextTurnAt).toBe(3250);
+  });
+
+  it("applies friction to moving animals", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 100, y: 100, vx: 120, vy: 0, nextTurnAt: 3000 }),
+      displaySpace: {
+        span: { w: 600, h: 600 },
+        spawnRegion: { x: 0, y: 0, w: 600, h: 600 },
+        movementRegions: [{ x: 0, y: 0, w: 600, h: 600 }],
+        hitTestScale: 1,
+      },
+      dtMs: 0,
+      nowMs: 1000,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(next.vx).toBeCloseTo(116.4);
+  });
+
+  it("keeps a minimum roaming speed after friction", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 100, y: 100, vx: 1, vy: 0, nextTurnAt: 3000 }),
+      displaySpace: {
+        span: { w: 600, h: 600 },
+        spawnRegion: { x: 0, y: 0, w: 600, h: 600 },
+        movementRegions: [{ x: 0, y: 0, w: 600, h: 600 }],
+        hitTestScale: 1,
+      },
+      dtMs: 0,
+      nowMs: 1000,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(Math.hypot(next.vx, next.vy)).toBeCloseTo(21);
+  });
+
+  it("advances animation frames on the frame interval", () => {
+    const next = advanceRanchAnimal({
+      animal: animal({ x: 100, y: 100, frameIndex: 3, lastFrameAt: 100, nextTurnAt: 3000 }),
+      displaySpace: {
+        span: { w: 600, h: 600 },
+        spawnRegion: { x: 0, y: 0, w: 600, h: 600 },
+        movementRegions: [{ x: 0, y: 0, w: 600, h: 600 }],
+        hitTestScale: 1,
+      },
+      dtMs: 0,
+      nowMs: 250,
+      frozen: false,
+      random: () => 0,
+    });
+
+    expect(next.frameIndex).toBe(0);
+    expect(next.lastFrameAt).toBe(250);
+  });
+});

--- a/src/lib/ranchAnimalMovement.ts
+++ b/src/lib/ranchAnimalMovement.ts
@@ -1,0 +1,183 @@
+import type { DisplaySpace, Rect } from "../types/display";
+
+export const RANCH_ANIMAL_SIZE = 48;
+export const RANCH_EDGE_MARGIN = 60;
+export const RANCH_ANIMAL_SPEED = 60;
+export const RANCH_FRICTION = 0.97;
+const MIN_SPEED_FRAC = 0.35;
+const FRAME_INTERVAL = 150;
+const MIN_TURN_MS = 3000;
+const MAX_TURN_MS = 8000;
+
+export type RanchAnimalDirection = "front" | "right" | "back" | "left";
+
+export interface RanchAnimalState {
+  readonly id: string;
+  readonly name: string;
+  readonly x: number;
+  readonly y: number;
+  readonly vx: number;
+  readonly vy: number;
+  readonly frameIndex: number;
+  readonly direction: RanchAnimalDirection;
+  readonly lastFrameAt: number;
+  readonly nextTurnAt: number;
+}
+
+export interface AdvanceRanchAnimalInput {
+  readonly animal: RanchAnimalState;
+  readonly displaySpace: DisplaySpace;
+  readonly dtMs: number;
+  readonly nowMs: number;
+  readonly frozen: boolean;
+  readonly random: () => number;
+}
+
+export function advanceRanchAnimal({
+  animal,
+  displaySpace,
+  dtMs,
+  nowMs,
+  random,
+  frozen,
+}: AdvanceRanchAnimalInput): RanchAnimalState {
+  if (frozen) {
+    return {
+      ...animal,
+      lastFrameAt: animal.lastFrameAt + dtMs,
+      nextTurnAt: animal.nextTurnAt + dtMs,
+    };
+  }
+
+  const steeringRegion = nearestRegion(animal.x, animal.y, displaySpace.movementRegions);
+  let { nextTurnAt } = animal;
+  let { frameIndex, lastFrameAt } = animal;
+  let vx = animal.vx * RANCH_FRICTION;
+  let vy = animal.vy * RANCH_FRICTION;
+
+  const speed = Math.hypot(vx, vy);
+  const minSpeed = RANCH_ANIMAL_SPEED * MIN_SPEED_FRAC;
+  if (speed < minSpeed && speed > 0) {
+    const scale = minSpeed / speed;
+    vx *= scale;
+    vy *= scale;
+  } else if (speed === 0) {
+    const angle = random() * 2 * Math.PI;
+    vx = Math.cos(angle) * minSpeed;
+    vy = Math.sin(angle) * minSpeed;
+  }
+
+  if (nowMs >= nextTurnAt) {
+    const angle = random() * 2 * Math.PI;
+    vx = Math.cos(angle) * RANCH_ANIMAL_SPEED;
+    vy = Math.sin(angle) * RANCH_ANIMAL_SPEED;
+    nextTurnAt = nowMs + MIN_TURN_MS + random() * (MAX_TURN_MS - MIN_TURN_MS);
+  }
+
+  let x = animal.x + vx * (dtMs / 1000);
+  let y = animal.y + vy * (dtMs / 1000);
+
+  if (steeringRegion) {
+    const minX = steeringRegion.x;
+    const maxX = steeringRegion.x + steeringRegion.w - RANCH_ANIMAL_SIZE;
+    const minY = steeringRegion.y;
+    const maxY = steeringRegion.y + steeringRegion.h - RANCH_ANIMAL_SIZE;
+    if (animal.x < minX + RANCH_EDGE_MARGIN) vx = Math.abs(vx);
+    if (animal.x > maxX - RANCH_EDGE_MARGIN) vx = -Math.abs(vx);
+    if (animal.y < minY + RANCH_EDGE_MARGIN) vy = Math.abs(vy);
+    if (animal.y > maxY - RANCH_EDGE_MARGIN) vy = -Math.abs(vy);
+    x = animal.x + vx * (dtMs / 1000);
+    y = animal.y + vy * (dtMs / 1000);
+  }
+
+  const point = nearestValidPoint(x, y, displaySpace.movementRegions);
+  if (point.x !== x) {
+    vx = x > point.x ? -Math.abs(vx) : Math.abs(vx);
+  }
+  if (point.y !== y) {
+    vy = y > point.y ? -Math.abs(vy) : Math.abs(vy);
+  }
+  x = point.x;
+  y = point.y;
+
+  if (nowMs - lastFrameAt >= FRAME_INTERVAL) {
+    frameIndex = (frameIndex + 1) % 4;
+    lastFrameAt = nowMs;
+  }
+
+  return {
+    ...animal,
+    x,
+    y,
+    vx,
+    vy,
+    frameIndex,
+    direction: direction4(vx, vy),
+    lastFrameAt,
+    nextTurnAt,
+  };
+}
+
+function nearestRegion(x: number, y: number, regions: readonly Rect[]): Rect | null {
+  if (regions.length === 0) return null;
+
+  let best = regions[0];
+  let bestPoint = clampPointToRegion(x, y, best);
+  let bestDistance = squaredDistance(x, y, bestPoint.x, bestPoint.y);
+
+  for (const region of regions.slice(1)) {
+    const point = clampPointToRegion(x, y, region);
+    const distance = squaredDistance(x, y, point.x, point.y);
+    if (distance < bestDistance) {
+      best = region;
+      bestPoint = point;
+      bestDistance = distance;
+    }
+  }
+
+  return best;
+}
+
+function direction4(vx: number, vy: number): RanchAnimalDirection {
+  if (Math.abs(vx) >= Math.abs(vy)) return vx >= 0 ? "right" : "left";
+  return vy >= 0 ? "front" : "back";
+}
+
+function nearestValidPoint(
+  x: number,
+  y: number,
+  regions: readonly Rect[],
+): { x: number; y: number } {
+  if (regions.length === 0) return { x, y };
+
+  let best = clampPointToRegion(x, y, regions[0]);
+  let bestDistance = squaredDistance(x, y, best.x, best.y);
+
+  for (const region of regions.slice(1)) {
+    const candidate = clampPointToRegion(x, y, region);
+    const distance = squaredDistance(x, y, candidate.x, candidate.y);
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+
+  return best;
+}
+
+function clampPointToRegion(x: number, y: number, region: Rect): { x: number; y: number } {
+  return {
+    x: clamp(x, region.x, region.x + region.w - RANCH_ANIMAL_SIZE),
+    y: clamp(y, region.y, region.y + region.h - RANCH_ANIMAL_SIZE),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function squaredDistance(ax: number, ay: number, bx: number, by: number): number {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}

--- a/src/types/display.ts
+++ b/src/types/display.ts
@@ -1,0 +1,18 @@
+export interface Rect {
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+export interface RectSize {
+  readonly w: number;
+  readonly h: number;
+}
+
+export interface DisplaySpace {
+  readonly span: RectSize;
+  readonly spawnRegion: Rect;
+  readonly movementRegions: readonly Rect[];
+  readonly hitTestScale: number;
+}

--- a/src/types/pig.ts
+++ b/src/types/pig.ts
@@ -1,10 +1,3 @@
-export interface SpawnRegion {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
-
 export interface PigHitRect {
   x: number;
   y: number;


### PR DESCRIPTION
## What changed

- Added a Rust `DisplaySpace` payload with span, spawn region, movement regions, and hit-test scale.
- Replaced the old primary-region-only event with `display-space`.
- Added a pure `advanceRanchAnimal` movement module for shared movement behavior.
- Updated `usePigMovement` to delegate roam/freeze/friction/turn/soft-steer/hard-clamp behavior to that module.
- Updated issue 049 and `CONTEXT.md` with the RanchAnimal/display-space decisions.

## Why

Issue file: `issues/049-display-space-pig-movement-seam.md`

Completion promise:

> RanchAnimal movement consumes a display-space interface instead of raw viewport dimensions and ad hoc primary-region rules; multi-monitor geometry policy is local to the display-space module.

This keeps monitor geometry policy local to Rust display-space computation and makes movement behavior testable without opening Tauri windows.

## Validation

- `task check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animals now automatically reposition to the nearest valid location when display configuration changes, rather than respawning
  * Enhanced movement with soft steering near movement region edges to prevent impacts, plus boundary clamping and velocity reflection when crossing limits
  * Improved multi-monitor support with normalized coordinate space across all enabled monitors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->