### PR TITLE
fix: remove release-please cargo workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,12 +3,6 @@
   "release-type": "rust",
   "bootstrap-sha": "b8a67c26adecb5036130d5e67af3aec5f98109b9",
   "include-component-in-tag": false,
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "updateAllPackages": true
-    }
-  ],
   "packages": {
     ".": {
       "package-name": "adhd-ranch",


### PR DESCRIPTION
## Summary
- remove the Release Please cargo-workspace plugin, which fails on this repo's version.workspace = true member manifests
- keep the root Rust strategy and explicit npm/Tauri extra files intact

## Why
The first main run failed with:

`release-please failed: cargo-workspace (killallgit/adhd-ranch): package manifest at src-tauri/Cargo.toml has an invalid [package.version]`

Release Please had already detected the Rust workspace and calculated the next version before the plugin ran, so the plugin is redundant here.

## Verification
- rtk node -e "for (const f of ['release-please-config.json','.release-please-manifest.json']) JSON.parse(require('fs').readFileSync(f, 'utf8')); console.log('release-please json ok')"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release configuration by streamlining settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->