### PR TITLE
fix: make release-please compatible with workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adhd-ranch"
-version = "0.0.0" # x-release-please-version
+version = "0.0.0"
 dependencies = [
  "adhd-ranch-commands",
  "adhd-ranch-domain",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-commands"
-version = "0.0.0" # x-release-please-version
+version = "0.0.0"
 dependencies = [
  "adhd-ranch-domain",
  "adhd-ranch-storage",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-domain"
-version = "0.0.0" # x-release-please-version
+version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-http-api"
-version = "0.0.0" # x-release-please-version
+version = "0.0.0"
 dependencies = [
  "adhd-ranch-commands",
  "adhd-ranch-domain",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-storage"
-version = "0.0.0" # x-release-please-version
+version = "0.0.0"
 dependencies = [
  "adhd-ranch-domain",
  "fs2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adhd-ranch"
-version = "0.0.0"
+version = "0.0.0" # x-release-please-version
 dependencies = [
  "adhd-ranch-commands",
  "adhd-ranch-domain",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-commands"
-version = "0.0.0"
+version = "0.0.0" # x-release-please-version
 dependencies = [
  "adhd-ranch-domain",
  "adhd-ranch-storage",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-domain"
-version = "0.0.0"
+version = "0.0.0" # x-release-please-version
 dependencies = [
  "serde",
  "serde_json",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-http-api"
-version = "0.0.0"
+version = "0.0.0" # x-release-please-version
 dependencies = [
  "adhd-ranch-commands",
  "adhd-ranch-domain",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adhd-ranch-storage"
-version = "0.0.0"
+version = "0.0.0" # x-release-please-version
 dependencies = [
  "adhd-ranch-domain",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
 edition = "2021"
 rust-version = "1.77"
 

--- a/crates/commands/Cargo.toml
+++ b/crates/commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adhd-ranch-commands"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adhd-ranch-domain"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/http-api/Cargo.toml
+++ b/crates/http-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adhd-ranch-http-api"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adhd-ranch-storage"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,8 +34,29 @@
           "jsonpath": "$.package.version"
         },
         {
-          "type": "generic",
-          "path": "Cargo.lock"
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[0].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[1].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[2].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[3].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[4].version"
         },
         {
           "type": "json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "node",
+  "release-type": "rust",
   "bootstrap-sha": "b8a67c26adecb5036130d5e67af3aec5f98109b9",
   "include-component-in-tag": false,
   "packages": {
@@ -9,34 +9,19 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {
-          "type": "toml",
-          "path": "Cargo.toml",
-          "jsonpath": "$.workspace.package.version"
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.version"
         },
         {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name=='adhd-ranch')].version"
+          "type": "json",
+          "path": "package-lock.json",
+          "jsonpath": "$.version"
         },
         {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name=='adhd-ranch-commands')].version"
-        },
-        {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name=='adhd-ranch-domain')].version"
-        },
-        {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name=='adhd-ranch-http-api')].version"
-        },
-        {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name=='adhd-ranch-storage')].version"
+          "type": "json",
+          "path": "package-lock.json",
+          "jsonpath": "$.packages[''].version"
         },
         {
           "type": "json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
+  "release-type": "node",
   "bootstrap-sha": "b8a67c26adecb5036130d5e67af3aec5f98109b9",
   "include-component-in-tag": false,
   "packages": {
@@ -12,21 +12,6 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
-        },
-        {
-          "type": "json",
-          "path": "package.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "package-lock.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "package-lock.json",
-          "jsonpath": "$.packages[''].version"
         },
         {
           "type": "json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "node",
   "bootstrap-sha": "b8a67c26adecb5036130d5e67af3aec5f98109b9",
   "include-component-in-tag": false,
   "packages": {
@@ -8,6 +8,35 @@
       "package-name": "adhd-ranch",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
+        {
+          "type": "toml",
+          "path": "src-tauri/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/domain/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/storage/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/commands/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/http-api/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "generic",
+          "path": "Cargo.lock"
+        },
         {
           "type": "json",
           "path": "package.json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "bootstrap-sha": "b8a67c26adecb5036130d5e67af3aec5f98109b9",
   "include-component-in-tag": false,
   "packages": {
@@ -8,6 +8,11 @@
       "package-name": "adhd-ranch",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        },
         {
           "type": "json",
           "path": "package.json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,31 @@
           "jsonpath": "$.workspace.package.version"
         },
         {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name=='adhd-ranch')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name=='adhd-ranch-commands')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name=='adhd-ranch-domain')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name=='adhd-ranch-http-api')].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name=='adhd-ranch-storage')].version"
+        },
+        {
           "type": "json",
           "path": "src-tauri/tauri.conf.json",
           "jsonpath": "$.version"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adhd-ranch"
-version.workspace = true
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Issue tracking for a five-year-old"


### PR DESCRIPTION
## Summary
- switch Release Please to the node strategy so it avoids the Rust strategy's virtual-workspace root updater
- make crate versions explicit instead of version.workspace so version files are directly updateable
- configure Release Please extra-files for all Rust manifests, Cargo.lock, Tauri config, and npm package files

## Verification
- rtk task check
- rtk npx release-please release-pr --repo-url=killallgit/adhd-ranch --target-branch=fix/release-please-simple --config-file=release-please-config.json --manifest-file=.release-please-manifest.json --dry-run --debug --token=...

## Notes
The dry run exits 0 and shows Release Please would open a 0.2.0 release PR, updating package-lock.json, package.json, all Rust manifests, Cargo.lock, src-tauri/tauri.conf.json, CHANGELOG.md, and .release-please-manifest.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version management configuration across multiple package manifests to use explicit version declarations instead of workspace inheritance.
  * Modified release configuration to support an updated release workflow process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/killallgit/adhd-ranch/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->